### PR TITLE
fix(ci): use tf instead of tofu

### DIFF
--- a/.github/workflows/_quality-checks.yaml
+++ b/.github/workflows/_quality-checks.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap install concierge --classic
-          sudo concierge prepare -p microk8s --extra-snaps=astral-uv,opentofu
+          sudo concierge prepare -p microk8s --extra-snaps=astral-uv,terraform
           sudo snap install kubectl --classic
           juju model-defaults automatically-retry-hooks=true
 


### PR DESCRIPTION
- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [x] Have you updated the documentation for this change?

-----

Recent OpenTofu release seems to break juju tf provider and it seems like there is no guarantee that the juju provider will support tofu. So use terraform in the CI instead of OpenTofu 