### PR TITLE
New IAM guide

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -69,6 +69,7 @@ traefik
 txt
 uncommenting
 ui
+url
 ztunnel
 utils
 VMs

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -28,10 +28,12 @@ Istio's
 Intersphinx
 iam
 io
+kratos
 lang
 LaTeX
 latexmk
 MeshPolicy
+metallb
 Mimir
 Multipass
 natively
@@ -63,6 +65,7 @@ TOC
 tex
 texlive
 toctree
+traefik
 txt
 uncommenting
 ui

--- a/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
+++ b/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
@@ -1,288 +1,82 @@
 # Authenticated Ingress with the Canonical Identity Platform
 
-## Introduction
-
-This guide demonstrates how to use the Canonical Identity Platform to add authentication to an Istio Ingress.
-
-## Prerequisites
-
-Before starting this guide, ensure you have:
-
-- Completed the [Get started with Charmed Istio ambient](../tutorial/get-started-with-the-charmed-istio-mesh.md) tutorial, which will give you a deployment of Istio ambient and the sample Bookinfo application ingressed through an istio-ingress
-- Deployed the Canonical Identity Platform following [this guide](https://charmhub.io/topics/canonical-identity-platform/tutorials/e2e-tutorial).  Specifically , you must complete [Deploy the Identity Platform](https://charmhub.io/topics/canonical-identity-platform/tutorials/e2e-tutorial#p-27742-deploy-the-identity-platform) and then [Set up a user with the built-in identity provider](https://charmhub.io/topics/canonical-identity-platform/tutorials/e2e-tutorial#p-27742-use-the-built-in-identity-provider)
-
-````{warning}
-Until [this issue](https://github.com/canonical/iam-bundle-integration/issues/66) is resolved, the Identity tutorial deploys an older version of [self-signed-certificates](https://github.com/canonical/self-signed-certificates-operator) that is incompatible with the [oauth2-proxy](https://github.com/canonical/oauth2-proxy-k8s-operator) charm used below.  
-
-To fix this, before doing `terraform apply` in the Identity Platform tutorial, edit the `certificates` variable in `examples/tutorial/variables.tf` to use a newer version:
-
-```
-variable "certificates" {
-  description = "The configurations of the self-signed-certificates application."
-  type = object({
-    units   = optional(number, 1)
-    trust   = optional(bool, true)
-    config  = optional(map(string), {})
-    channel = optional(string, "1/stable")     # <-- EDIT: previously "latest/stable"
-    base    = optional(string, "ubuntu@24.04") # <-- EDIT: previously "ubuntu@22.04"
-  })
-  default = {}
-}
-```
-
-and the `traefik` variable to:
-
-```
-variable "traefik" {
-  description = "The configurations of the Traefik application."
-  type = object({
-    units   = optional(number, 1)
-    trust   = optional(bool, true)
-    config  = optional(map(string), {})
-    channel = optional(string, "latest/edge") # <-- EDIT: previously "latest/stable"
-    base    = optional(string, "ubuntu@20.04")
-  })
-  default = {}
-}
-```
-
-````
-
-Applying This should yield a starting point similar to:
-
-````{dropdown} juju status --relations --model iam
-```
-Model  Controller      Cloud/Region              Version  SLA          Timestamp
-iam    local-microk8s  local-microk8s/localhost  3.6.8    unsupported  16:50:58-04:00
-
-SAAS        Status  Store  URL
-ingress     active  local  admin/core.ingress
-postgresql  active  local  admin/core.postgresql
-
-App       Version  Status  Scale  Charm                                Channel        Rev  Address         Exposed  Message
-hydra     v2.3.0   active      1  hydra                                latest/stable  362  10.152.183.168  no            
-kratos    v1.3.1   active      1  kratos                               latest/stable  527  10.152.183.136  no       
-login-ui  0.20.0   active      1  identity-platform-login-ui-operator  latest/stable  166  10.152.183.37   no        
-
-Unit         Workload  Agent  Address       Ports  Message
-hydra/0*     active    idle   10.1.253.238                
-kratos/0*    active    idle   10.1.253.245         
-login-ui/0*  active    idle   10.1.253.241             
-
-Offer              Application  Charm   Rev  Connected  Endpoint     Interface    Role
-kratos-info-offer  kratos       kratos  527  0/0        kratos-info  kratos_info  provider
-oauth-offer        hydra        hydra   362  0/0        oauth        oauth        provider
-
-Integration provider                 Requirer                             Interface                         Type     Message
-hydra:hydra                          hydra:hydra                          hydra_peers                       peer     
-hydra:hydra-endpoint-info            kratos:hydra-endpoint-info           hydra_endpoints                   regular  
-hydra:hydra-endpoint-info            login-ui:hydra-endpoint-info         hydra_endpoints                   regular  
-ingress:ingress                      hydra:public-ingress                 ingress                           regular  
-ingress:ingress                      kratos:public-ingress                ingress                           regular  
-ingress:ingress                      login-ui:ingress                     ingress                           regular  
-kratos:kratos-info                   login-ui:kratos-info                 kratos_info                       regular  
-kratos:kratos-peers                  kratos:kratos-peers                  kratos-peers                      peer     
-login-ui:identity-platform-login-ui  login-ui:identity-platform-login-ui  identity_platform_login_ui_peers  peer     
-login-ui:ui-endpoint-info            hydra:ui-endpoint-info               login_ui_endpoints                regular  
-login-ui:ui-endpoint-info            kratos:ui-endpoint-info              login_ui_endpoints                regular  
-postgresql:database                  hydra:pg-database                    postgresql_client                 regular  
-postgresql:database                  kratos:pg-database                   postgresql_client                 regular
-```
-````
-
-````{dropdown} juju status --relations --model core
-```
-Model  Controller      Cloud/Region              Version  SLA          Timestamp
-core   local-microk8s  local-microk8s/localhost  3.6.8    unsupported  16:51:56-04:00
-
-App                       Version  Status  Scale  Charm                     Channel        Rev  Address         Exposed  Message
-postgresql-k8s            14.15    active      1  postgresql-k8s            14/stable      495  10.152.183.109  no       
-self-signed-certificates           active      1  self-signed-certificates  1/stable       317  10.152.183.149  no        
-traefik-public            2.11.0   active      1  traefik-k8s               latest/edge    242  10.152.183.234  no       Serving at 10.64.140.44
-
-Unit                         Workload  Agent  Address       Ports  Message
-postgresql-k8s/0*            active    idle   10.1.253.243         Primary
-self-signed-certificates/0*  active    idle   10.1.253.237         
-traefik-public/0*            active    idle   10.1.253.244         Serving at 10.64.140.44
-
-Offer          Application               Charm                     Rev  Connected  Endpoint       Interface             Role
-ingress        traefik-public            traefik-k8s               236  3/3        ingress        ingress               provider
-postgresql     postgresql-k8s            postgresql-k8s            495  2/2        database       postgresql_client     provider
-send-ca-cert   self-signed-certificates  self-signed-certificates  317  0/0        send-ca-cert   certificate_transfer  provider
-traefik-route  traefik-public            traefik-k8s               236  0/0        traefik-route  traefik_route         provider
-
-Integration provider                   Requirer                       Interface         Type     Message
-postgresql-k8s:database-peers          postgresql-k8s:database-peers  postgresql_peers  peer     
-postgresql-k8s:restart                 postgresql-k8s:restart         rolling_op        peer     
-postgresql-k8s:upgrade                 postgresql-k8s:upgrade         upgrade           peer     
-self-signed-certificates:certificates  traefik-public:certificates    tls-certificates  regular  
-traefik-public:peers                   traefik-public:peers           traefik_peers     peer
-```
-````
-
-````{dropdown} juju status --relations --model istio-system
-```
-Model         Controller      Cloud/Region              Version  SLA          Timestamp
-istio-system  local-microk8s  local-microk8s/localhost  3.6.8    unsupported  16:52:40-04:00
-
-App                Version  Status  Scale  Charm              Channel  Rev  Address        Exposed  Message
-istio-ingress-k8s           active      1  istio-ingress-k8s  2/edge    43  10.152.183.28  no       Serving at 10.64.140.43
-istio-k8s                   active      1  istio-k8s          2/edge    38  10.152.183.75  no            
-
-Unit                  Workload  Agent  Address       Ports  Message
-istio-ingress-k8s/0*  active    idle   10.1.253.202         Serving at 10.64.140.43
-istio-k8s/0*          active    idle   10.1.253.201             
-
-Offer              Application        Charm              Rev  Connected  Endpoint                 Interface  Role
-istio-ingress-k8s  istio-ingress-k8s  istio-ingress-k8s  43   1/1        ingress                  ingress    provider
-                                                                         ingress-unauthenticated  ingress    provider
-
-Integration provider     Requirer                 Interface                Type  Message
-istio-ingress-k8s:peers  istio-ingress-k8s:peers  istio_ingress_k8s_peers  peer  
-istio-k8s:peers          istio-k8s:peers          istio_k8s_peers          peer
-```
-````
-
-````{dropdown} juju status --relations --model bookinfo
-```
-Model     Controller      Cloud/Region              Version  SLA          Timestamp
-bookinfo  local-microk8s  local-microk8s/localhost  3.6.8    unsupported  16:53:08-04:00
-
-SAAS               Status  Store           URL
-istio-ingress-k8s  active  local-microk8s  admin/istio-system.istio-ingress-k8s
-
-App                       Version  Status  Scale  Charm                     Channel        Rev  Address         Exposed  Message
-bookinfo-details-k8s               active      1  bookinfo-details-k8s      latest/stable    1  10.152.183.173  no       Ready
-bookinfo-productpage-k8s           active      1  bookinfo-productpage-k8s  latest/stable    1  10.152.183.141  no       Ready with 2 backend services
-bookinfo-reviews-k8s               active      1  bookinfo-reviews-k8s      latest/stable    1  10.152.183.145  no       Running version v1
-istio-beacon-k8s                   active      1  istio-beacon-k8s          2/edge          38  10.152.183.105  no       
-
-Unit                         Workload  Agent  Address       Ports  Message
-bookinfo-details-k8s/0*      active    idle   10.1.253.247         Ready
-bookinfo-productpage-k8s/0*  active    idle   10.1.253.248         Ready with 2 backend services
-bookinfo-reviews-k8s/0*      active    idle   10.1.253.250         Running version v1
-istio-beacon-k8s/0*          active    idle   10.1.253.246             
 
-Integration provider           Requirer                               Interface               Type     Message
-bookinfo-details-k8s:details   bookinfo-productpage-k8s:details       bookinfo-details        regular
-bookinfo-reviews-k8s:reviews   bookinfo-productpage-k8s:reviews       bookinfo-reviews        regular
-istio-beacon-k8s:peers         istio-beacon-k8s:peers                 istio_beacon_k8s_peers  peer
-istio-beacon-k8s:service-mesh  bookinfo-details-k8s:service-mesh      service_mesh            regular
-istio-beacon-k8s:service-mesh  bookinfo-productpage-k8s:service-mesh  service_mesh            regular
-istio-beacon-k8s:service-mesh  bookinfo-reviews-k8s:service-mesh      service_mesh            regular
-istio-ingress-k8s:ingress      bookinfo-productpage-k8s:ingress       ingress                 regular
-```
-````
 
-From this stage, we can:
-* browse to the Bookinfo application.  The URL is of the format `https://ISTIO_INGRESS_IP/bookinfo-bookinfo-productpage-k8s/productpage?u=normal` - use `juju run --model bookinfo bookinfo-productpage-k8s/leader get-url` to obtain the real URL.
-* log into the Identity login page (login ui).  The URL is of the format `https://TRAEFIK_IP/iam-login-ui/ui/login` - use `juju run --model core traefik-public/leader show-proxied-endpoints` to obtain the real URL.
+This tutorial uses three Juju models:
 
-But browsing to the Bookinfo application did not require any authentication.  Next, we configure the Istio ingress to enforce authentication using the Identity Platform.
+- `iam` for the Canonical Identity Platform
+- `istio-system` for Istio control-plane and ingress components
+- `bookinfo` for the sample workload and oauth2 proxy
 
-```{note}
-Throughout this guide you will log into the identity platform a few times.  While it works in any browser configuration, using incognito sessions is recommended because its easy to close the session to reset any login cookies.  Its recommended that every time you try to log in fresh, you close your incognito session and start a new one.
-```
+Keeping these in separate models makes cross-model integration explicit and easier to debug.
 
-## Configure the Identity Platform to use the Istio Ingress
+## Requirements
 
-### Configure the Istio Ingress to use TLS
+* A [microk8s cluster cluster](https://canonical.com/microk8s/docs/getting-started#1-overview)
 
-The Identity Platform by default requires everything to be ingressed using https, but the [Get started with Charmed Istio](../tutorial/get-started-with-the-charmed-istio-mesh.md) tutorial used http.  To enable https, we can obtain certificates from the `self-signed-certificates` provided deployed in the Identity Platform tutorial by offering the certificate provider:
+> **Note**
+> This tutorial requires you to have 2 IP addresses available to your k8s cluster. One for the traefik deployed with the identity bundle and one for istio-ingress-k8s. This can be done by enabling metallb with an IP range. For example:
+> `microk8s enable metallb:192.168.0.XXX-192.168.0.YYY`
 
-```bash
-juju offer core.self-signed-certificates:certificates certificates
-```
+* A [bootstrapped juju controller](https://documentation.ubuntu.com/juju/3.6/tutorial/)
+* [Terraform](https://snapcraft.io/terraform) (For the identity tutorial)
 
-and using it in istio-ingress-k8s:
+For a smoother run, make sure your cluster has enough resources (at least 4 vCPU and 8 GB RAM is recommended), and that DNS and load balancer support are enabled in your Kubernetes environment.
 
-```bash
-juju consume --model istio-system core.certificates
-juju relate --model istio-system istio-ingress-k8s:certificates certificates
-```
+## Setup the prerequisites
 
-### Ingress the Identity Platform through Istio
+* Deploy the [Canonical Identity Platform](https://canonical-identity.readthedocs-hosted.com/tutorial/canonical-identity-platform/)
 
-Out of the box, the [Identity Platform tutorial](https://charmhub.io/topics/canonical-identity-platform/tutorials/e2e-tutorial) uses [Traefik](https://github.com/canonical/traefik-k8s-operator) as an ingress.  To reconfigure that deployment to use our istio-ingress-k8s, consume the istio-ingress-k8s in the iam model:
+> **Note**
+> If you see hydra and kratos in blocked state with "Missing integration pg-database", run the following:
+> ```bash
+> juju switch iam
+> juju integrate hydra postgresql
+> juju integrate kratos postgresql
+> ```
 
-```bash
-juju consume --model iam istio-system.istio-ingress-k8s
-```
+> **Note**
+> If you do not want to bother with 2 factor authentication for the tutorial, you can run:
+> ```bash
+> juju config kratos enforce_mfa=false
+> ```
 
-Then change the ingress for all the Identity charms from Traefik to istio-ingress-k8s:
+* `juju add-model istio-system`
+* `juju deploy istio-k8s istio --trust --channel dev/edge`
+* `juju offer istio:istio-ingress-config ingress-config`
+* Wait for istio to reach active/idle
 
-```bash
-juju remove-relation --model iam hydra:public-ingress ingress
-juju relate --model iam hydra:public-ingress istio-ingress-k8s:ingress-unauthenticated
-juju remove-relation --model iam kratos:public-ingress ingress
-juju relate --model iam kratos:public-ingress istio-ingress-k8s:ingress-unauthenticated
-juju remove-relation --model iam login-ui:ingress ingress
-juju relate --model iam login-ui:ingress istio-ingress-k8s:ingress-unauthenticated
-```
+## Deploy Authenticated Bookinfo
 
-Once this settles, we should be able to complete the login flow through the new ingress at `https://ISTIO_INGRESS_IP/iam-login-ui/ui/login`.
+### Deploy the Charms
 
-## Add Authentication to the Istio Ingress using the Identity Platform
+* `juju add-model bookinfo`
+* `juju deploy oauth2-proxy-k8s oauth2`
+* `juju config oauth2 dev=true`
+* `juju deploy istio-ingress-k8s ingress --trust --channel dev/edge`
+* `juju deploy bookinfo-productpage-k8s bookinfo`
+* `juju deploy bookinfo-details-k8s bookinfo-details`
 
-By default, traffic is allowed through the Istio Ingress unauthenticated.  To add an authentication flow to that traffic, we connect the istio-ingress-k8s to istio-k8s to send additional configurations:
+### Consume Cross-Model Integrations
 
-```bash
-juju relate --model istio-system istio-ingress-k8s:istio-ingress-config istio-k8s:istio-ingress-config
-```
+* `juju consume iam.oauth-offer`
+* `juju consume istio-system.ingress-config`
+* `juju consume core.send-ca-cert`
+* `juju consume core.certificates`
 
-deploy `oauth2-proxy`:
+### Integrate your charms
 
-```bash
-# Deploy oauth2-proxy and provide it with certificates used by other applications
-juju deploy --model istio-system oauth2-proxy-k8s oauth2-proxy --channel=edge --trust
-juju consume --model istio-system core.send-ca-cert
-juju relate --model istio-system oauth2-proxy:receive-ca-cert send-ca-cert
-juju relate --model istio-system oauth2-proxy:ingress istio-ingress-k8s:ingress-unauthenticated
-```
+* `juju integrate bookinfo:details bookinfo-details:details`
+* `juju integrate bookinfo:ingress ingress:ingress`
+* `juju integrate oauth2 oauth-offer`
+* `juju integrate oauth2:forward-auth ingress:forward-auth`
+* `juju integrate oauth2:receive-ca-cert send-ca-cert`
+* `juju integrate ingress ingress-config`
+* `juju integrate ingress:certificates certificates`
+* `juju integrate oauth2:ingress ingress:ingress-unauthenticated`
+* Wait for all charms to reach active/idle
 
-and connect `oauth2-proxy` to the identity platform and istio-ingress:
+### Test your deployment
 
-```bash
-juju consume --model istio-system iam.oauth-offer
-juju relate --model istio-system oauth2-proxy:oauth oauth-offer
-
-juju relate --model istio-system oauth2-proxy:forward-auth istio-ingress-k8s:forward-auth
-```
-
-Now when we browse to the Bookinfo application at `https://ISTIO_INGRESS_IP/bookinfo-bookinfo-productpage-k8s/productpage?u=normal`, we will be prompted first to log in through the Identity Platform.
-
-## How to ingress some applications without authentication
-
-istio-ingress-k8s offers two `ingress` integration endpoints, `ingress` and `ingress-unauthenticated`.  These both support the same interface, but differ in how they handle authentication:
-* `ingress`: traffic ingressed using this integration **will always be authenticated *if authentication is configured on this istio-ingress-k8s***, otherwise traffic will be unauthenticated
-* `ingress-unauthenticated`: traffic ingressed using this integration **will never be authenticated**
-
-Typically, `ingress` is the integration you need.  But when some applications need to selectively be offered without authentication, use `ingress-unauthenticated` to keep them unrestricted.  
-
-To try this out, deploy the [catalogue-k8s](https://github.com/canonical/catalogue-k8s-operator/) charm and ingress it without authentication:
-
-```bash
-juju deploy --model bookinfo catalogue-k8s catalogue
-juju relate --model catalogue istio-ingress-k8s:ingress-unauthenticated
-```
-
-Now (in a new browser session, just so you know you're not already logged in) browse to Catalogue at `https://ISTIO_INGRESS_IP/bookinfo-catalogue`.  The application will be accessible without a login.
-
-## Wrapping up
-
-Congratulations!  You've successfully:
-
-- configured istio-ingress-k8s to use the Identity Platform for authentication
-- logged into the Identity Platform to access an application
-- deployed an application that is never authenticated
-
-## Teardown
-
-To clean up the resources created in this guide, run:
-
-```bash
-juju destroy-model iam
-juju destroy-model core
-juju destroy-model istio-system
-juju destroy-model bookinfo
-```
+* Navigate to `http://<ingress-address>/bookinfo-bookinfo` in your browser. You should be prompted to log in.
+* Log in and access the bookinfo page!

--- a/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
+++ b/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
@@ -1,15 +1,5 @@
 # Authenticated Ingress with the Canonical Identity Platform
 
-
-
-This tutorial uses three Juju models:
-
-- `iam` for the Canonical Identity Platform
-- `istio-system` for Istio control-plane and ingress components
-- `bookinfo` for the sample workload and oauth2 proxy
-
-Keeping these in separate models makes cross-model integration explicit and easier to debug.
-
 ## Requirements
 
 * A [microk8s cluster cluster](https://canonical.com/microk8s/docs/getting-started#1-overview)

--- a/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
+++ b/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
@@ -12,8 +12,6 @@ This tutorial requires you to have 2 IP addresses available to your k8s cluster.
 * A [bootstrapped juju controller](https://documentation.ubuntu.com/juju/3.6/tutorial/)
 * [Terraform](https://snapcraft.io/terraform) (For the identity tutorial)
 
-For a smoother run, make sure your cluster has enough resources (at least 4 vCPU and 8 GB RAM is recommended), and that DNS and load balancer support are enabled in your Kubernetes environment.
-
 ## Set up the prerequisites
 
 * Deploy the [Canonical Identity Platform](https://canonical-identity.readthedocs-hosted.com/tutorial/canonical-identity-platform/)

--- a/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
+++ b/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
@@ -23,7 +23,7 @@ See [the docs](https://canonical.com/microk8s/docs/addon-metallb) for more info.
 
 ````{note}
 If you see hydra and kratos in blocked state with "Missing integration pg-database", run the following:
-```{bash}
+```{code} bash
 juju switch iam
 juju integrate hydra postgresql
 juju integrate kratos postgresql
@@ -32,13 +32,13 @@ juju integrate kratos postgresql
 
 ````{note}
 If you do not want to bother with 2 factor authentication for the tutorial, you can run:
-```{bash}
+```{code} bash
 juju config kratos enforce_mfa=false
 ```
 ````
 
 * Next we deploy istio to the cluster, enabling it to manage network traffic.
-  ```{bash}
+  ```{code} bash
   juju add-model istio-system
   juju deploy istio-k8s istio --trust --channel dev/edge
   juju offer istio:istio-ingress-config ingress-config
@@ -53,14 +53,14 @@ Any release track newer than 2 should work just fine.
 ## Deploy Authenticated Bookinfo
 
 * Deploy the bookinfo application
-  ```{bash}
+  ```{code} bash
   juju add-model bookinfo
   juju deploy bookinfo-productpage-k8s bookinfo
   juju deploy bookinfo-details-k8s bookinfo-details
   juju integrate bookinfo:details bookinfo-details:details
   ```
 * Deploy oauth2-proxy and integrate it with the Identity Platform
-  ```{bash}
+  ```{code} bash
   juju deploy oauth2-proxy-k8s oauth2
   juju config oauth2 dev=true  # dev=true is required since the certificates we will be using are self-signed.
   juju consume core.send-ca-cert
@@ -69,7 +69,7 @@ Any release track newer than 2 should work just fine.
   juju integrate oauth2 oauth-offer
   ```
 * Deploy istio-ingress and use it to route traffic to bookinfo and oauth2-proxy
-  ```{bash}
+  ```{code} bash
   juju deploy istio-ingress-k8s ingress --trust --channel dev/edge
   juju consume core.certificates
   juju integrate ingress:certificates certificates
@@ -79,13 +79,16 @@ Any release track newer than 2 should work just fine.
 At this point, after waiting for everything to settle, you should be able to run `juju run bookinfo/leader get-url` and it should return an https url. If you navigate to the returned url in your browser, you should reach the bookinfo app.
 
 * Enable authentication
-  ```{bash}
+  ```{code} bash
   juju integrate oauth2:forward-auth ingress:forward-auth
   juju consume istio-system.ingress-config
   juju integrate ingress ingress-config
   ```
-Wait for all charms to reach active/idle
+Wait for all charms to reach active/idle then run `juju run bookinfo/leader get-url` and navigate to the returned URL in your browser. You should be prompted to log in. Log in and access the bookinfo page!
 
-### Test your deployment
-
-* Run `juju run bookinfo/leader get-url` and navigate to the returned URL in your browser. You should be prompted to log in. Log in and access the bookinfo page!
+````{note}
+There is currently a bug in istio-ingress which may cause the url return by `juju run bookinfo/leader get-url` to be an http url (non TLS). If so you need to recreate the relation to certificates and it should work
+```{code} bash
+juju remove-relation ingress certificates
+juju integrate ingress certificates
+```

--- a/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
+++ b/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
@@ -13,7 +13,7 @@
 
 For a smoother run, make sure your cluster has enough resources (at least 4 vCPU and 8 GB RAM is recommended), and that DNS and load balancer support are enabled in your Kubernetes environment.
 
-## Setup the prerequisites
+## Set up the prerequisites
 
 * Deploy the [Canonical Identity Platform](https://canonical-identity.readthedocs-hosted.com/tutorial/canonical-identity-platform/)
 

--- a/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
+++ b/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
@@ -90,5 +90,6 @@ Wait for all charms to reach active/idle then run `juju run bookinfo/leader get-
 There is currently a bug in istio-ingress which may cause the url return by `juju run bookinfo/leader get-url` to be an http url (non TLS). If so you need to recreate the relation to certificates and it should work
 ```{code} bash
 juju remove-relation ingress certificates
+sleep 5
 juju integrate ingress certificates
 ```

--- a/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
+++ b/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
@@ -1,12 +1,17 @@
 # Authenticated Ingress with the Canonical Identity Platform
 
+## Introduction
+
+In this tutorial, you will learn how to set up authentication for any application using Istio and the Canonical Identity Platform. We will deploy the sample "bookinfo" application and configure Istio to redirect unauthenticated traffic to oauth2-proxy.
+
 ## Requirements
 
 * A [MicroK8s cluster](https://canonical.com/microk8s/docs/getting-started)
 
 ```{note}
-This tutorial requires you to have 2 IP addresses available to your k8s cluster. One for the traefik deployed with the identity bundle and one for istio-ingress-k8s. This can be done by enabling metallb with an IP range. For example:
+This tutorial requires you to have 2 IP addresses available to your k8s cluster. One for the traefik instance deployed with the identity bundle and one for istio-ingress-k8s. This can be done by enabling metallb with an IP range. For example:
 `microk8s enable metallb:192.168.0.XXX-192.168.0.YYY`
+See [the docs](https://canonical.com/microk8s/docs/addon-metallb) for more info.
 ```
 
 * A [bootstrapped juju controller](https://documentation.ubuntu.com/juju/3.6/tutorial/)
@@ -14,11 +19,11 @@ This tutorial requires you to have 2 IP addresses available to your k8s cluster.
 
 ## Set up the prerequisites
 
-* Deploy the [Canonical Identity Platform](https://canonical-identity.readthedocs-hosted.com/tutorial/canonical-identity-platform/)
+* First follow the tutorial to deploy the [Canonical Identity Platform](https://canonical-identity.readthedocs-hosted.com/tutorial/canonical-identity-platform/). This is what will be used to manage users and authentication.
 
 ````{note}
 If you see hydra and kratos in blocked state with "Missing integration pg-database", run the following:
-```bash
+```{bash}
 juju switch iam
 juju integrate hydra postgresql
 juju integrate kratos postgresql
@@ -27,15 +32,18 @@ juju integrate kratos postgresql
 
 ````{note}
 If you do not want to bother with 2 factor authentication for the tutorial, you can run:
-```bash
+```{bash}
 juju config kratos enforce_mfa=false
 ```
 ````
 
-* `juju add-model istio-system`
-* `juju deploy istio-k8s istio --trust --channel dev/edge`
-* `juju offer istio:istio-ingress-config ingress-config`
-* Wait for istio to reach active/idle
+* Next we deploy istio to the cluster, enabling it to manage network traffic.
+  ```{bash}
+  juju add-model istio-system
+  juju deploy istio-k8s istio --trust --channel dev/edge
+  juju offer istio:istio-ingress-config ingress-config
+  ```
+  Then Wait for istio to reach active/idle.
 
 ```{note}
 We need to use the `dev` track for the Istio charms currently as the 2 track has an old Istio version.
@@ -44,35 +52,40 @@ Any release track newer than 2 should work just fine.
 
 ## Deploy Authenticated Bookinfo
 
-### Deploy the Charms
+* Deploy the bookinfo application
+  ```{bash}
+  juju add-model bookinfo
+  juju deploy bookinfo-productpage-k8s bookinfo
+  juju deploy bookinfo-details-k8s bookinfo-details
+  juju integrate bookinfo:details bookinfo-details:details
+  ```
+* Deploy oauth2-proxy and integrate it with the Identity Platform
+  ```{bash}
+  juju deploy oauth2-proxy-k8s oauth2
+  juju config oauth2 dev=true  # dev=true is required since the certificates we will be using are self-signed.
+  juju consume core.send-ca-cert
+  juju integrate oauth2:receive-ca-cert send-ca-cert
+  juju consume iam.oauth-offer
+  juju integrate oauth2 oauth-offer
+  ```
+* Deploy istio-ingress and use it to route traffic to bookinfo and oauth2-proxy
+  ```{bash}
+  juju deploy istio-ingress-k8s ingress --trust --channel dev/edge
+  juju consume core.certificates
+  juju integrate ingress:certificates certificates
+  juju integrate bookinfo:ingress ingress:ingress
+  juju integrate oauth2:ingress ingress:ingress-unauthenticated
+  ```
+At this point, after waiting for everything to settle, you should be able to run `juju run bookinfo/leader get-url` and it should return an https url. If you navigate to the returned url in your browser, you should reach the bookinfo app.
 
-* `juju add-model bookinfo`
-* `juju deploy oauth2-proxy-k8s oauth2`
-* `juju config oauth2 dev=true`
-* `juju deploy istio-ingress-k8s ingress --trust --channel dev/edge`
-* `juju deploy bookinfo-productpage-k8s bookinfo`
-* `juju deploy bookinfo-details-k8s bookinfo-details`
-
-### Consume Cross-Model Integrations
-
-* `juju consume iam.oauth-offer`
-* `juju consume istio-system.ingress-config`
-* `juju consume core.send-ca-cert`
-* `juju consume core.certificates`
-
-### Integrate your charms
-
-* `juju integrate bookinfo:details bookinfo-details:details`
-* `juju integrate bookinfo:ingress ingress:ingress`
-* `juju integrate oauth2 oauth-offer`
-* `juju integrate oauth2:forward-auth ingress:forward-auth`
-* `juju integrate oauth2:receive-ca-cert send-ca-cert`
-* `juju integrate ingress ingress-config`
-* `juju integrate ingress:certificates certificates`
-* `juju integrate oauth2:ingress ingress:ingress-unauthenticated`
-* Wait for all charms to reach active/idle
+* Enable authentication
+  ```{bash}
+  juju integrate oauth2:forward-auth ingress:forward-auth
+  juju consume istio-system.ingress-config
+  juju integrate ingress ingress-config
+  ```
+Wait for all charms to reach active/idle
 
 ### Test your deployment
 
-* Run `juju run bookinfo/leader get-url` and navigate to the returned URL in your browser. You should be prompted to log in.
-* Log in and access the bookinfo page!
+* Run `juju run bookinfo/leader get-url` and navigate to the returned URL in your browser. You should be prompted to log in. Log in and access the bookinfo page!

--- a/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
+++ b/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
@@ -4,9 +4,10 @@
 
 * A [MicroK8s cluster](https://canonical.com/microk8s/docs/getting-started#1-overview)
 
-> **Note**
-> This tutorial requires you to have 2 IP addresses available to your k8s cluster. One for the traefik deployed with the identity bundle and one for istio-ingress-k8s. This can be done by enabling metallb with an IP range. For example:
-> `microk8s enable metallb:192.168.0.XXX-192.168.0.YYY`
+```{note}
+This tutorial requires you to have 2 IP addresses available to your k8s cluster. One for the traefik deployed with the identity bundle and one for istio-ingress-k8s. This can be done by enabling metallb with an IP range. For example:
+`microk8s enable metallb:192.168.0.XXX-192.168.0.YYY`
+```
 
 * A [bootstrapped juju controller](https://documentation.ubuntu.com/juju/3.6/tutorial/)
 * [Terraform](https://snapcraft.io/terraform) (For the identity tutorial)
@@ -17,28 +18,31 @@ For a smoother run, make sure your cluster has enough resources (at least 4 vCPU
 
 * Deploy the [Canonical Identity Platform](https://canonical-identity.readthedocs-hosted.com/tutorial/canonical-identity-platform/)
 
-> **Note**
-> If you see hydra and kratos in blocked state with "Missing integration pg-database", run the following:
-> ```bash
-> juju switch iam
-> juju integrate hydra postgresql
-> juju integrate kratos postgresql
-> ```
+````{note}
+If you see hydra and kratos in blocked state with "Missing integration pg-database", run the following:
+```bash
+juju switch iam
+juju integrate hydra postgresql
+juju integrate kratos postgresql
+```
+````
 
-> **Note**
-> If you do not want to bother with 2 factor authentication for the tutorial, you can run:
-> ```bash
-> juju config kratos enforce_mfa=false
-> ```
+````{note}
+If you do not want to bother with 2 factor authentication for the tutorial, you can run:
+```bash
+juju config kratos enforce_mfa=false
+```
+````
 
 * `juju add-model istio-system`
 * `juju deploy istio-k8s istio --trust --channel dev/edge`
 * `juju offer istio:istio-ingress-config ingress-config`
 * Wait for istio to reach active/idle
 
-> **Note**
-> We need to use the `dev` track for the Istio charms currently as the 2 track has an old Istio version.
-> Any release track newer than 2 should work just fine.
+```{note}
+We need to use the `dev` track for the Istio charms currently as the 2 track has an old Istio version.
+Any release track newer than 2 should work just fine.
+```
 
 ## Deploy Authenticated Bookinfo
 

--- a/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
+++ b/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
@@ -36,6 +36,10 @@ For a smoother run, make sure your cluster has enough resources (at least 4 vCPU
 * `juju offer istio:istio-ingress-config ingress-config`
 * Wait for istio to reach active/idle
 
+> **Note**
+> We need to use the `dev` track for the Istio charms currently as the 2 track has an old Istio version.
+> Any release track newer than 2 should work just fine.
+
 ## Deploy Authenticated Bookinfo
 
 ### Deploy the Charms

--- a/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
+++ b/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
@@ -72,5 +72,5 @@ For a smoother run, make sure your cluster has enough resources (at least 4 vCPU
 
 ### Test your deployment
 
-* Navigate to `http://<ingress-address>/bookinfo-bookinfo` in your browser. You should be prompted to log in.
+* Run `juju run bookinfo/leader get-url` and navigate to the returned URL in your browser. You should be prompted to log in.
 * Log in and access the bookinfo page!

--- a/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
+++ b/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-* A [microk8s cluster cluster](https://canonical.com/microk8s/docs/getting-started#1-overview)
+* A [MicroK8s cluster](https://canonical.com/microk8s/docs/getting-started#1-overview)
 
 > **Note**
 > This tutorial requires you to have 2 IP addresses available to your k8s cluster. One for the traefik deployed with the identity bundle and one for istio-ingress-k8s. This can be done by enabling metallb with an IP range. For example:

--- a/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
+++ b/docs/how-to/authenticated-ingress-with-the-canonical-identity-platform.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-* A [MicroK8s cluster](https://canonical.com/microk8s/docs/getting-started#1-overview)
+* A [MicroK8s cluster](https://canonical.com/microk8s/docs/getting-started)
 
 ```{note}
 This tutorial requires you to have 2 IP addresses available to your k8s cluster. One for the traefik deployed with the identity bundle and one for istio-ingress-k8s. This can be done by enabling metallb with an IP range. For example:


### PR DESCRIPTION
Fixes #46

Brand new tutorial that focuses only on using Istio for authentication, rather than putting the identity stack on the mesh.

The file is completely new so it is likely easier to view the plain file than the diff.