### PR TITLE
fix(istio): migrate istio scheduled tests to dev/edge

### DIFF
--- a/.github/workflows/scheduled-tests.yaml
+++ b/.github/workflows/scheduled-tests.yaml
@@ -15,4 +15,4 @@ jobs:
   quality-checks:
     uses: ./.github/workflows/_quality-checks.yaml
     with:
-      istio-channel: "2/edge"
+      istio-channel: "dev/edge"


### PR DESCRIPTION
Upgrades the scheduled tests to run on dev/edge so the scheduled tests arent broken anymore.

This is needed because of a recent upgrade to the tf module in main which expects a track specific channel name through a validation. Plus no one is using track 2. its more useful to test the dev (to be track 3) track
