### PR TITLE
chore[canonical-service-mesh]: adds missing request headers

### DIFF
--- a/canonical_service_mesh/src/canonical_service_mesh/interfaces/istio_ingress_config/_istio_ingress_config.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/interfaces/istio_ingress_config/_istio_ingress_config.py
@@ -22,7 +22,15 @@ if TYPE_CHECKING:
 # Default headers for external authorization.
 # These defaults are based on oauth2-proxy requirements and can be used by ingress charms
 # when no headers are provided by the auth provider.
-DEFAULT_INCLUDE_HEADERS_IN_CHECK = ["authorization", "cookie"]
+DEFAULT_INCLUDE_HEADERS_IN_CHECK = [
+    "authorization",
+    "cookie",
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-forwarded-uri",
+    "x-forwarded-prefix",
+]
 DEFAULT_HEADERS_TO_UPSTREAM_ON_ALLOW = [
     "authorization",
     "path",


### PR DESCRIPTION
Tandem PR for https://github.com/canonical/istio-ingress-k8s-operator/pull/163
