### PR TITLE
fix: shorten long label names

### DIFF
--- a/canonical_service_mesh/src/canonical_service_mesh/k8s/resource_manager/_resource_manager.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/k8s/resource_manager/_resource_manager.py
@@ -20,6 +20,7 @@ from lightkube.types import PatchType
 from ops import CharmBase
 
 from ...enums import MeshType
+from ...utils import charm_kubernetes_label
 from ...utils.istio._policy_builder import (
     POLICY_RESOURCE_TYPES,
     build_policy_resources_istio,
@@ -213,10 +214,15 @@ class KubernetesResourceManager:
         self.patch(resources=resources, force=force, patch_type=patch_type)
 
 
-def create_charm_default_labels(application_name: str, model_name: str, scope: str) -> dict:
+def create_charm_default_labels(
+    application_name: str, model_name: str, scope: str
+) -> Dict[str, str]:
     """Return a default label style for the KubernetesResourceHandler label selector."""
+    instance_label = charm_kubernetes_label(
+        model_name=model_name, app_name=application_name, separator="-"
+    )
     return {
-        "app.kubernetes.io/instance": f"{application_name}-{model_name}",
+        "app.kubernetes.io/instance": instance_label,
         "kubernetes-resource-handler-scope": scope,
     }
 

--- a/canonical_service_mesh/tests/unit/test_resource_manager.py
+++ b/canonical_service_mesh/tests/unit/test_resource_manager.py
@@ -19,6 +19,7 @@ from canonical_service_mesh.k8s.resource_manager._resource_manager import (
     _hash_lightkube_resource,
     _in_left_not_right,
     _validate_resources,
+    create_charm_default_labels,
 )
 
 DEFAULT_LABELS = {"label": "default"}
@@ -188,3 +189,15 @@ def test_get_resource_classes_in_manifests():
 def test_validate_resources(resources, allowed, ctx):
     with ctx:
         _validate_resources(resources, allowed)
+
+
+@pytest.mark.parametrize("model_name", ["a", "b" * 63, "c" * 64], ids=["m1", "m63", "m64"])
+@pytest.mark.parametrize("app_name", ["a", "b" * 63, "c" * 64], ids=["a1", "a63", "a64"])
+def test_create_charm_default_labels__maxlength(model_name, app_name):
+    labels = create_charm_default_labels(app_name, model_name, "testscope")
+    assert len(labels["app.kubernetes.io/instance"]) <= 63
+
+
+def test_create_charm_default_labels__short_names():
+    labels = create_charm_default_labels("abcde", "fghij", "testscope")
+    assert labels["app.kubernetes.io/instance"] == "fghij-abcde"


### PR DESCRIPTION
This is a port of [this PR](https://github.com/canonical/lightkube-extensions/pull/13).

Closes #70.

Since the fix reuses a helper method, the label is now "<model_name>-<app_name>" instead of the old "<app_name>-<model_name>" for for cases not requiring shortening.


-----
