### PR TITLE
charm workflows for mono repo

### DIFF
--- a/.github/workflows/charm-promote.yaml
+++ b/.github/workflows/charm-promote.yaml
@@ -11,12 +11,8 @@ on:
           - beta -> candidate
           - candidate -> stable
       charm:
-        type: choice
-        description: Charm to promote
-        options:
-          - istio-k8s
-          - istio-beacon-k8s
-          - istio-ingress-k8s
+        type: string
+        description: Charm to promote (directory name under charms/)
 
 jobs:
   promote:

--- a/.github/workflows/charm-promote.yaml
+++ b/.github/workflows/charm-promote.yaml
@@ -1,0 +1,28 @@
+name: Promote Charm
+
+on:
+  workflow_dispatch:
+    inputs:
+      promotion:
+        type: choice
+        description: Channel to promote from
+        options:
+          - edge -> beta
+          - beta -> candidate
+          - candidate -> stable
+      charm:
+        type: choice
+        description: Charm to promote
+        options:
+          - istio-k8s
+          - istio-beacon-k8s
+          - istio-ingress-k8s
+
+jobs:
+  promote:
+    name: Promote
+    uses: canonical/observability/.github/workflows/charm-promote.yaml@v2
+    with:
+      promotion: ${{ github.event.inputs.promotion }}
+      charm-path: charms/${{ github.event.inputs.charm }}
+    secrets: inherit

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -6,38 +6,28 @@ on:
       - main
       - track/**
     paths:
-      # If you update these paths, also update the filters in the 'changes' job below
-      - charms/istio-k8s/**
-      - charms/istio-beacon-k8s/**
-      - charms/istio-ingress-k8s/**
+      - charms/**
 
 jobs:
-  changes:
-    name: Detect changed charms
+  discover-charms:
+    name: Discover charms
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
     outputs:
-      charms: ${{ steps.filter.outputs.changes }}
+      charms: ${{ steps.discover.outputs.charms }}
     steps:
-      - uses: dorny/paths-filter@v4
-        id: filter
+      - uses: actions/checkout@v4
         with:
-          filters: |
-            charms/istio-k8s:
-              - charms/istio-k8s/**
-            charms/istio-beacon-k8s:
-              - charms/istio-beacon-k8s/**
-            charms/istio-ingress-k8s:
-              - charms/istio-ingress-k8s/**
+          sparse-checkout: charms
+          sparse-checkout-cone-mode: true
+      - id: discover
+        run: echo "charms=$(ls -d1 charms/* | jq -Rsc 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
 
   pull-request:
     name: PR (${{ matrix.charm-path }})
-    needs: changes
-    if: ${{ needs.changes.outputs.charms != '[]' }}
+    needs: discover-charms
     strategy:
       matrix:
-        charm-path: ${{ fromJSON(needs.changes.outputs.charms) }}
+        charm-path: ${{ fromJSON(needs.discover-charms.outputs.charms) }}
       fail-fast: false
     uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v2
     with:

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -1,0 +1,45 @@
+name: Pull Requests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - track/**
+    paths:
+      # If you update these paths, also update the filters in the 'changes' job below
+      - charms/istio-k8s/**
+      - charms/istio-beacon-k8s/**
+      - charms/istio-ingress-k8s/**
+
+jobs:
+  changes:
+    name: Detect changed charms
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      charms: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            charms/istio-k8s:
+              - charms/istio-k8s/**
+            charms/istio-beacon-k8s:
+              - charms/istio-beacon-k8s/**
+            charms/istio-ingress-k8s:
+              - charms/istio-ingress-k8s/**
+
+  pull-request:
+    name: PR (${{ matrix.charm-path }})
+    needs: changes
+    if: ${{ needs.changes.outputs.charms != '[]' }}
+    strategy:
+      matrix:
+        charm-path: ${{ fromJSON(needs.changes.outputs.charms) }}
+      fail-fast: false
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v2
+    with:
+      charm-path: ${{ matrix.charm-path }}
+    secrets: inherit

--- a/.github/workflows/charm-pull-request.yaml
+++ b/.github/workflows/charm-pull-request.yaml
@@ -1,4 +1,4 @@
-name: Pull Requests
+name: Charm Pull Requests
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ jobs:
     outputs:
       charms: ${{ steps.discover.outputs.charms }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: charms
           sparse-checkout-cone-mode: true

--- a/.github/workflows/charm-quality-gates.yaml
+++ b/.github/workflows/charm-quality-gates.yaml
@@ -8,7 +8,6 @@ on:
         type: choice
         description: Charm to run quality gates for
         options:
-          - all
           - istio-beacon-k8s
           - istio-ingress-k8s
           - istio-k8s
@@ -17,47 +16,11 @@ on:
   # schedule:
   #   - cron: "0 0 * * Tue"
 
-permissions:
-  contents: read
-
 
 jobs:
-  set-charms:
-    name: Set charm matrix
-    runs-on: ubuntu-latest
-    outputs:
-      charms: ${{ steps.set-charms.outputs.charms }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          sparse-checkout: charms
-          sparse-checkout-cone-mode: true
-      - name: Set charms matrix
-        id: set-charms
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.charm }}" != "all" ]]; then
-            echo 'charms=["charms/${{ inputs.charm }}"]' >> "$GITHUB_OUTPUT"
-          else
-            if [[ ! -d charms ]]; then
-              echo "charms/ directory not found" >&2
-              exit 1
-            fi
-            charms=$(find charms -mindepth 1 -maxdepth 1 -type d -not -name '.*' | sort | jq -Rsc 'split("\n")[:-1]')
-            if [[ "$charms" == "[]" ]]; then
-              echo "No charms found under charms/" >&2
-              exit 1
-            fi
-            echo "charms=$charms" >> "$GITHUB_OUTPUT"
-          fi
-
   quality-gates:
-    name: Run quality gates (${{ matrix.charm-path }})
-    needs: set-charms
-    strategy:
-      matrix:
-        charm-path: ${{ fromJSON(needs.set-charms.outputs.charms) }}
-      fail-fast: false
+    name: Run quality gates
     uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v2
     with:
-      charm-path: ${{ matrix.charm-path }}
+      charm-path: charms/${{ github.event.inputs.charm }}
     secrets: inherit

--- a/.github/workflows/charm-quality-gates.yaml
+++ b/.github/workflows/charm-quality-gates.yaml
@@ -8,6 +8,7 @@ on:
         type: choice
         description: Charm to run quality gates for
         options:
+          - all
           - istio-beacon-k8s
           - istio-ingress-k8s
           - istio-k8s
@@ -17,9 +18,33 @@ on:
   #   - cron: "0 0 * * Tue"
 
 jobs:
+  set-charms:
+    name: Set charm matrix
+    runs-on: ubuntu-latest
+    outputs:
+      charms: ${{ steps.set-charms.outputs.charms }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: charms
+          sparse-checkout-cone-mode: true
+      - name: Set charms matrix
+        id: set-charms
+        run: |
+          if [[ "${{ inputs.charm }}" != "all" ]]; then
+            echo 'charms=["charms/${{ inputs.charm }}"]' >> "$GITHUB_OUTPUT"
+          else
+            echo "charms=$(ls -d1 charms/* | jq -Rsc 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
+          fi
+
   quality-gates:
-    name: Run quality gates
+    name: Run quality gates (${{ matrix.charm-path }})
+    needs: set-charms
+    strategy:
+      matrix:
+        charm-path: ${{ fromJSON(needs.set-charms.outputs.charms) }}
+      fail-fast: false
     uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v2
     with:
-      charm-path: charms/${{ inputs.charm }}
+      charm-path: ${{ matrix.charm-path }}
     secrets: inherit

--- a/.github/workflows/charm-quality-gates.yaml
+++ b/.github/workflows/charm-quality-gates.yaml
@@ -17,6 +17,9 @@ on:
   # schedule:
   #   - cron: "0 0 * * Tue"
 
+permissions:
+  contents: read
+
 
 jobs:
   set-charms:
@@ -35,7 +38,12 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.charm }}" != "all" ]]; then
             echo 'charms=["charms/${{ inputs.charm }}"]' >> "$GITHUB_OUTPUT"
           else
-            echo "charms=$(ls -d1 charms/* | jq -Rsc 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
+            charms=$(find charms -mindepth 1 -maxdepth 1 -type d | sort | jq -Rsc 'split("\n")[:-1]')
+            if [[ "$charms" == "[]" ]]; then
+              echo "No charms found under charms/" >&2
+              exit 1
+            fi
+            echo "charms=$charms" >> "$GITHUB_OUTPUT"
           fi
 
   quality-gates:

--- a/.github/workflows/charm-quality-gates.yaml
+++ b/.github/workflows/charm-quality-gates.yaml
@@ -5,12 +5,8 @@ on:
   workflow_dispatch:
     inputs:
       charm:
-        type: choice
-        description: Charm to run quality gates for
-        options:
-          - istio-k8s
-          - istio-beacon-k8s
-          - istio-ingress-k8s
+        type: string
+        description: Charm to run quality gates for (directory name under charms/)
   # Run the quality checks periodically
   # FIXME: adjust the frequency as needed once we have actual gates in place
   # schedule:

--- a/.github/workflows/charm-quality-gates.yaml
+++ b/.github/workflows/charm-quality-gates.yaml
@@ -38,6 +38,10 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.charm }}" != "all" ]]; then
             echo 'charms=["charms/${{ inputs.charm }}"]' >> "$GITHUB_OUTPUT"
           else
+            if [[ ! -d charms ]]; then
+              echo "charms/ directory not found" >&2
+              exit 1
+            fi
             charms=$(find charms -mindepth 1 -maxdepth 1 -type d | sort | jq -Rsc 'split("\n")[:-1]')
             if [[ "$charms" == "[]" ]]; then
               echo "No charms found under charms/" >&2

--- a/.github/workflows/charm-quality-gates.yaml
+++ b/.github/workflows/charm-quality-gates.yaml
@@ -16,10 +16,6 @@ on:
   # schedule:
   #   - cron: "0 0 * * Tue"
 
-permissions:
-  contents: read
-
-
 jobs:
   quality-gates:
     name: Run quality gates

--- a/.github/workflows/charm-quality-gates.yaml
+++ b/.github/workflows/charm-quality-gates.yaml
@@ -1,0 +1,26 @@
+name: Quality Gates
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+    inputs:
+      charm:
+        type: choice
+        description: Charm to run quality gates for
+        options:
+          - istio-k8s
+          - istio-beacon-k8s
+          - istio-ingress-k8s
+  # Run the quality checks periodically
+  # FIXME: adjust the frequency as needed once we have actual gates in place
+  # schedule:
+  #   - cron: "0 0 * * Tue"
+
+
+jobs:
+  quality-gates:
+    name: Run quality gates
+    uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v2
+    with:
+      charm-path: charms/${{ github.event.inputs.charm }}
+    secrets: inherit

--- a/.github/workflows/charm-quality-gates.yaml
+++ b/.github/workflows/charm-quality-gates.yaml
@@ -16,11 +16,14 @@ on:
   # schedule:
   #   - cron: "0 0 * * Tue"
 
+permissions:
+  contents: read
+
 
 jobs:
   quality-gates:
     name: Run quality gates
     uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v2
     with:
-      charm-path: charms/${{ github.event.inputs.charm }}
+      charm-path: charms/${{ inputs.charm }}
     secrets: inherit

--- a/.github/workflows/charm-quality-gates.yaml
+++ b/.github/workflows/charm-quality-gates.yaml
@@ -42,7 +42,7 @@ jobs:
               echo "charms/ directory not found" >&2
               exit 1
             fi
-            charms=$(find charms -mindepth 1 -maxdepth 1 -type d | sort | jq -Rsc 'split("\n")[:-1]')
+            charms=$(find charms -mindepth 1 -maxdepth 1 -type d -not -name '.*' | sort | jq -Rsc 'split("\n")[:-1]')
             if [[ "$charms" == "[]" ]]; then
               echo "No charms found under charms/" >&2
               exit 1

--- a/.github/workflows/charm-quality-gates.yaml
+++ b/.github/workflows/charm-quality-gates.yaml
@@ -5,8 +5,13 @@ on:
   workflow_dispatch:
     inputs:
       charm:
-        type: string
-        description: Charm to run quality gates for (directory name under charms/)
+        type: choice
+        description: Charm to run quality gates for
+        options:
+          - istio-beacon-k8s
+          - istio-ingress-k8s
+          - istio-k8s
+          - kiali-k8s
   # Run the quality checks periodically
   # FIXME: adjust the frequency as needed once we have actual gates in place
   # schedule:

--- a/.github/workflows/charm-quality-gates.yaml
+++ b/.github/workflows/charm-quality-gates.yaml
@@ -8,10 +8,10 @@ on:
         type: choice
         description: Charm to run quality gates for
         options:
+          - all
           - istio-beacon-k8s
           - istio-ingress-k8s
           - istio-k8s
-          - kiali-k8s
   # Run the quality checks periodically
   # FIXME: adjust the frequency as needed once we have actual gates in place
   # schedule:
@@ -19,9 +19,33 @@ on:
 
 
 jobs:
+  set-charms:
+    name: Set charm matrix
+    runs-on: ubuntu-latest
+    outputs:
+      charms: ${{ steps.set-charms.outputs.charms }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: charms
+          sparse-checkout-cone-mode: true
+      - name: Set charms matrix
+        id: set-charms
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.charm }}" != "all" ]]; then
+            echo 'charms=["charms/${{ inputs.charm }}"]' >> "$GITHUB_OUTPUT"
+          else
+            echo "charms=$(ls -d1 charms/* | jq -Rsc 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
+          fi
+
   quality-gates:
-    name: Run quality gates
+    name: Run quality gates (${{ matrix.charm-path }})
+    needs: set-charms
+    strategy:
+      matrix:
+        charm-path: ${{ fromJSON(needs.set-charms.outputs.charms) }}
+      fail-fast: false
     uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v2
     with:
-      charm-path: charms/${{ github.event.inputs.charm }}
+      charm-path: ${{ matrix.charm-path }}
     secrets: inherit

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -5,8 +5,7 @@ on:
     inputs:
       charm:
         type: string
-        description: Which charm to release (directory name under charms/, or "all")
-        default: all
+        description: Which charm to release (directory name under charms/, or leave empty for all)
   push:
     branches:
       - main
@@ -21,14 +20,14 @@ jobs:
     outputs:
       charms: ${{ steps.set-charms.outputs.charms }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: charms
           sparse-checkout-cone-mode: true
       - name: Set charms matrix
         id: set-charms
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.charm }}" != "all" ]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.charm }}" ]]; then
             echo 'charms=["charms/${{ inputs.charm }}"]' >> "$GITHUB_OUTPUT"
           else
             echo "charms=$(ls -d1 charms/* | jq -Rsc 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -4,8 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       charm:
-        type: string
-        description: Which charm to release (directory name under charms/, or leave empty for all)
+        type: choice
+        description: Which charm to release
+        options:
+          - all
+          - istio-beacon-k8s
+          - istio-ingress-k8s
+          - istio-k8s
+          - kiali-k8s
   push:
     branches:
       - main
@@ -27,7 +33,7 @@ jobs:
       - name: Set charms matrix
         id: set-charms
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.charm }}" ]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.charm }}" != "all" ]]; then
             echo 'charms=["charms/${{ inputs.charm }}"]' >> "$GITHUB_OUTPUT"
           else
             echo "charms=$(ls -d1 charms/* | jq -Rsc 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -1,0 +1,70 @@
+name: Release Charm to Edge and Publish Libraries
+
+on:
+  workflow_dispatch:
+    inputs:
+      charm:
+        type: choice
+        description: Which charm to release
+        default: all
+        options:
+          - all
+          - istio-k8s
+          - istio-beacon-k8s
+          - istio-ingress-k8s
+  push:
+    branches:
+      - main
+      - track/**
+    paths:
+      # If you update these paths, also update the filters in the 'changes' job below
+      - charms/istio-k8s/**
+      - charms/istio-beacon-k8s/**
+      - charms/istio-ingress-k8s/**
+
+jobs:
+  changes:
+    name: Detect changed charms
+    runs-on: ubuntu-latest
+    outputs:
+      charms: ${{ steps.set-charms.outputs.charms }}
+    steps:
+      - uses: actions/checkout@v4
+        if: ${{ github.event_name == 'push' }}
+      - uses: dorny/paths-filter@v4
+        if: ${{ github.event_name == 'push' }}
+        id: filter
+        with:
+          filters: |
+            charms/istio-k8s:
+              - charms/istio-k8s/**
+            charms/istio-beacon-k8s:
+              - charms/istio-beacon-k8s/**
+            charms/istio-ingress-k8s:
+              - charms/istio-ingress-k8s/**
+      - name: Set charms matrix
+        id: set-charms
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ "${{ inputs.charm }}" == "all" ]]; then
+              echo 'charms=["charms/istio-k8s","charms/istio-beacon-k8s","charms/istio-ingress-k8s"]' >> "$GITHUB_OUTPUT"
+            else
+              echo 'charms=["charms/${{ inputs.charm }}"]' >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo 'charms=${{ steps.filter.outputs.changes }}' >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    name: Release (${{ matrix.charm-path }})
+    needs: changes
+    if: ${{ needs.changes.outputs.charms != '[]' }}
+    strategy:
+      matrix:
+        charm-path: ${{ fromJSON(needs.changes.outputs.charms) }}
+      fail-fast: false
+    uses: canonical/observability/.github/workflows/charm-release.yaml@v2
+    secrets: inherit
+    with:
+      charm-path: ${{ matrix.charm-path }}
+      default-track: dev

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -4,64 +4,42 @@ on:
   workflow_dispatch:
     inputs:
       charm:
-        type: choice
-        description: Which charm to release
+        type: string
+        description: Which charm to release (directory name under charms/, or "all")
         default: all
-        options:
-          - all
-          - istio-k8s
-          - istio-beacon-k8s
-          - istio-ingress-k8s
   push:
     branches:
       - main
       - track/**
     paths:
-      # If you update these paths, also update the filters in the 'changes' job below
-      - charms/istio-k8s/**
-      - charms/istio-beacon-k8s/**
-      - charms/istio-ingress-k8s/**
+      - charms/**
 
 jobs:
-  changes:
-    name: Detect changed charms
+  set-charms:
+    name: Set charm matrix
     runs-on: ubuntu-latest
     outputs:
       charms: ${{ steps.set-charms.outputs.charms }}
     steps:
       - uses: actions/checkout@v4
-        if: ${{ github.event_name == 'push' }}
-      - uses: dorny/paths-filter@v4
-        if: ${{ github.event_name == 'push' }}
-        id: filter
         with:
-          filters: |
-            charms/istio-k8s:
-              - charms/istio-k8s/**
-            charms/istio-beacon-k8s:
-              - charms/istio-beacon-k8s/**
-            charms/istio-ingress-k8s:
-              - charms/istio-ingress-k8s/**
+          sparse-checkout: charms
+          sparse-checkout-cone-mode: true
       - name: Set charms matrix
         id: set-charms
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            if [[ "${{ inputs.charm }}" == "all" ]]; then
-              echo 'charms=["charms/istio-k8s","charms/istio-beacon-k8s","charms/istio-ingress-k8s"]' >> "$GITHUB_OUTPUT"
-            else
-              echo 'charms=["charms/${{ inputs.charm }}"]' >> "$GITHUB_OUTPUT"
-            fi
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.charm }}" != "all" ]]; then
+            echo 'charms=["charms/${{ inputs.charm }}"]' >> "$GITHUB_OUTPUT"
           else
-            echo 'charms=${{ steps.filter.outputs.changes }}' >> "$GITHUB_OUTPUT"
+            echo "charms=$(ls -d1 charms/* | jq -Rsc 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
           fi
 
   release:
     name: Release (${{ matrix.charm-path }})
-    needs: changes
-    if: ${{ needs.changes.outputs.charms != '[]' }}
+    needs: set-charms
     strategy:
       matrix:
-        charm-path: ${{ fromJSON(needs.changes.outputs.charms) }}
+        charm-path: ${{ fromJSON(needs.set-charms.outputs.charms) }}
       fail-fast: false
     uses: canonical/observability/.github/workflows/charm-release.yaml@v2
     secrets: inherit

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -11,7 +11,6 @@ on:
           - istio-beacon-k8s
           - istio-ingress-k8s
           - istio-k8s
-          - kiali-k8s
   push:
     branches:
       - main

--- a/.github/workflows/charm-tiobe-scan.yaml
+++ b/.github/workflows/charm-tiobe-scan.yaml
@@ -1,0 +1,21 @@
+name: Tiobe TiCS Analysis
+
+on:
+    workflow_dispatch:
+    schedule:
+    - cron: "0 0 * * 1"  # Runs at midnight UTC every Monday
+
+jobs:
+    tics:
+        name: TiCs (${{ matrix.charm-path }})
+        strategy:
+            matrix:
+                charm-path:
+                    - charms/istio-k8s
+                    - charms/istio-beacon-k8s
+                    - charms/istio-ingress-k8s
+            fail-fast: false
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v2
+        with:
+            charm-path: ${{ matrix.charm-path }}
+        secrets: inherit

--- a/.github/workflows/charm-tiobe-scan.yaml
+++ b/.github/workflows/charm-tiobe-scan.yaml
@@ -12,7 +12,7 @@ jobs:
         outputs:
             charms: ${{ steps.discover.outputs.charms }}
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
           with:
             sparse-checkout: charms
             sparse-checkout-cone-mode: true

--- a/.github/workflows/charm-tiobe-scan.yaml
+++ b/.github/workflows/charm-tiobe-scan.yaml
@@ -6,14 +6,25 @@ on:
     - cron: "0 0 * * 1"  # Runs at midnight UTC every Monday
 
 jobs:
+    discover-charms:
+        name: Discover charms
+        runs-on: ubuntu-latest
+        outputs:
+            charms: ${{ steps.discover.outputs.charms }}
+        steps:
+        - uses: actions/checkout@v4
+          with:
+            sparse-checkout: charms
+            sparse-checkout-cone-mode: true
+        - id: discover
+          run: echo "charms=$(ls -d1 charms/* | jq -Rsc 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
+
     tics:
         name: TiCs (${{ matrix.charm-path }})
+        needs: discover-charms
         strategy:
             matrix:
-                charm-path:
-                    - charms/istio-k8s
-                    - charms/istio-beacon-k8s
-                    - charms/istio-ingress-k8s
+                charm-path: ${{ fromJSON(needs.discover-charms.outputs.charms) }}
             fail-fast: false
         uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v2
         with:

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -1,0 +1,23 @@
+name: Auto-update Charm Libraries
+on:
+  # Manual trigger
+  workflow_dispatch:
+  # Check regularly the upstream every four hours
+  schedule:
+    - cron: "0 0,4,8,12,16,20 * * *"
+
+jobs:
+  update-lib:
+    name: Check libraries (${{ matrix.charm-path }})
+    strategy:
+      matrix:
+        charm-path:
+          - charms/istio-k8s
+          - charms/istio-beacon-k8s
+          - charms/istio-ingress-k8s
+      fail-fast: false
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v2
+    with:
+      charm-path: ${{ matrix.charm-path }}
+    secrets: inherit
+

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -7,14 +7,25 @@ on:
     - cron: "0 0,4,8,12,16,20 * * *"
 
 jobs:
+  discover-charms:
+    name: Discover charms
+    runs-on: ubuntu-latest
+    outputs:
+      charms: ${{ steps.discover.outputs.charms }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: charms
+          sparse-checkout-cone-mode: true
+      - id: discover
+        run: echo "charms=$(ls -d1 charms/* | jq -Rsc 'split("\n")[:-1]')" >> "$GITHUB_OUTPUT"
+
   update-lib:
     name: Check libraries (${{ matrix.charm-path }})
+    needs: discover-charms
     strategy:
       matrix:
-        charm-path:
-          - charms/istio-k8s
-          - charms/istio-beacon-k8s
-          - charms/istio-ingress-k8s
+        charm-path: ${{ fromJSON(needs.discover-charms.outputs.charms) }}
       fail-fast: false
     uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v2
     with:

--- a/.github/workflows/charm-update-libs.yaml
+++ b/.github/workflows/charm-update-libs.yaml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       charms: ${{ steps.discover.outputs.charms }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: charms
           sparse-checkout-cone-mode: true


### PR DESCRIPTION
New CI for the charms.

Assumes a root level `charms` directory with each charm being a sub-directory.

Only runs the CI for a charm if *that* charm had changes.

The quality gates workflow supports an `all` option to run gates across all charms via a matrix strategy.

- [ ] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change?

-----