### PR TITLE
chore(docs): add a CMR mesh relation warning and explanation

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -52,6 +52,7 @@ QEMU
 Rockcraft
 readthedocs
 rst
+SaaS
 ServiceMeshConsumer
 SVG
 scalable
@@ -73,6 +74,7 @@ url
 ztunnel
 utils
 VMs
+walkthrough
 waypoint
 waypoints
 Waypoint

--- a/docs/explanation/cross-model-mesh.md
+++ b/docs/explanation/cross-model-mesh.md
@@ -1,6 +1,6 @@
 # Cross-model mesh
 
-The Beacon charm automatically generates authorization policies based on the juju integrations that are in place at a given time. But, when two applications integrated with one another live in different Juju models, the Beacon charm cannot generate a correct authorization policy from a normal Juju cross-model relation and the `service-mesh` relation alone. The `cross_model_mesh` interface (exposed as the `provide-cmr-mesh` and `require-cmr-mesh` endpoints) exists to fill that gap, and it introduces one constraint on how cross-model offers must be structured.
+The Beacon charm automatically generates authorization policies based on the Juju integrations that are in place at a given time. But, when two applications integrated with one another live in different Juju models, the Beacon charm cannot generate a correct authorization policy from a normal Juju cross-model relation and the `service-mesh` relation alone. The `cross_model_mesh` interface (exposed as the `provide-cmr-mesh` and `require-cmr-mesh` endpoints) exists to fill that gap, and it introduces one constraint on how cross-model offers must be structured.
 
 ## Why a dedicated cross-model interface is needed
 
@@ -9,31 +9,41 @@ A service mesh authorization policy identifies the source of allowed traffic by 
 * the **real application name** in the remote model
 * the **real model name** the remote application is deployed in
 
-Juju does not expose either of these across a cross-model relation. On the consumer side, an offer is consumed as a Software-as-a-Service (SAAS) under a local alias, and that local alias is the only name the providing side ever sees on the relation (`relation.app.name`). It has no relationship to the actual remote application name, and the remote model name is not surfaced at all.
+Juju does not expose either of these across a cross-model relation. On the consumer side, an offer is consumed as a Software-as-a-Service (SaaS) under a local alias, and that local alias is the only name the providing side ever sees on the relation (`relation.app.name`). It has no relationship to the actual remote application name, and the remote model name is not surfaced at all.
 
-The `cross_model_mesh` interface works around this by carrying the real `app_name` and `juju_model_name` of the consuming application explicitly in its relation data. The Beacon charm reads this payload and uses it, instead of the local SAAS alias, to build the source principal of the generated `AuthorizationPolicy`.
+The `cross_model_mesh` interface works around this by carrying the real `app_name` and `juju_model_name` of the consuming application explicitly in its relation data. The Beacon charm reads this payload and uses it, instead of the local SaaS alias, to build the source principal of the generated `AuthorizationPolicy`.
 
 ## How the correlation works
 
-When Beacon builds policies, it iterates over each service-mesh relation (for example `metrics-endpoint`, `reviews`, `ingress`) and, for each one, looks up the matching `cross_model_mesh` relation to discover the real source identity. The lookup key is the remote application as seen locally, that is, the local SAAS name on the relation.
+When Beacon builds policies, it iterates over each relation that a policy applies to (for example an established relation on the `metrics-endpoint`, `reviews`, or `ingress` charm endpoint) and looks up the matching `cross_model_mesh` relation to discover the real source identity. The lookup key is the remote application as seen locally, that is, the local SaaS name on the relation.
 
-This means the workload relation and the `cross_model_mesh` relation must arrive on the providing side under the **same** SAAS. Only then does the Beacon charm know that a given `cross_model_mesh` payload describes the source of a given workload relation.
+This means both relations must arrive on the providing side under the **same** SaaS. Only then does the Beacon charm know that a given `cross_model_mesh` payload describes the source of a given relation.
 
-## Limitation: group cross-model endpoints into a single offer
+## Limitation: every offer with a workload endpoint must also include `provide-cmr-mesh`
 
-A Juju offer produces exactly one SAAS on the consumer side, and each SAAS in a consuming model must have a unique local name. As a direct consequence:
+A Juju offer produces exactly one SaaS on the consumer side, and each SaaS in a consuming model has its own unique local name. Because Beacon correlates a charm relation with its corresponding `cross_model_mesh` relation data by **matching the local SaaS name on both relations**, the rule is:
 
-> All endpoints of a remote application that require an authorization policy, together with the `provide-cmr-mesh` endpoint, must be exposed through a **single** Juju offer.
+> Every Juju offer that exposes an endpoint requiring an authorization policy must also expose the `provide-cmr-mesh` endpoint.
 
-If the workload endpoint and `provide-cmr-mesh` are exposed through separate offers, the consumer ends up with two different SAAS names backing the same remote application. The providing Beacon receives the two relations under two unrelated local names and cannot correlate them. The lookup silently falls back to the local SAAS alias as the source name, producing an `AuthorizationPolicy` whose source principal does not match any real workload. The policy is silently ineffective: cross-model traffic that should be allowed is denied (in hardened mode), or, if a permissive rule happens to match for unrelated reasons, granted under the wrong identity.
+If a charm endpoint is exposed in an offer that does not also include `provide-cmr-mesh`, the consumer ends up with a SaaS for the charm relation that has no matching `cross_model_mesh` endpoint under the same local name. The providing Beacon silently falls back to the local SaaS alias as the source name, and produces an `AuthorizationPolicy` whose source principal does not match any real charm's principal. The policy is silently ineffective: cross-model traffic that should be allowed is denied (in hardened mode), or, if a permissive rule happens to match for unrelated reasons, granted under the wrong identity.
 
-The same applies when multiple workload endpoints on a remote application each need their own policy. They must all be grouped into the single offer that also exposes `provide-cmr-mesh`. For example:
+There are two equivalent ways to satisfy the rule:
 
-```bash
-juju offer my-app:reviews,metrics-endpoint,ingress,provide-cmr-mesh
-```
+* **One offer bundling everything.** Group all charm endpoints together with `provide-cmr-mesh` into a single offer:
 
-This is a structural limitation of Juju cross-model relations and cannot be worked around in the mesh charms or library.
+  ```bash
+  juju offer my-app:reviews,metrics-endpoint,ingress,provide-cmr-mesh
+  ```
+
+* **Multiple offers, each one self-contained.** Re-expose `provide-cmr-mesh` in every offer that carries a charm endpoint:
+
+  ```bash
+  juju offer my-app:reviews,provide-cmr-mesh           # consumed as e.g. my-app-reviews
+  juju offer my-app:metrics-endpoint,provide-cmr-mesh  # consumed as e.g. my-app-metrics
+  ```
+
+  Each offer becomes its own SaaS on the consumer side, and each SaaS carries both a workload relation and a `cross_model_mesh` relation under the same local name, so Beacon correlates each pair independently.
+
 ## See also
 
 * [Use the Istio mesh across different Juju models](../tutorial/use-the-istio-mesh-across-different-juju-models.md): tutorial walkthrough of a cross-model mesh setup.

--- a/docs/explanation/cross-model-mesh.md
+++ b/docs/explanation/cross-model-mesh.md
@@ -1,6 +1,6 @@
 # Cross-model mesh
 
-When two applications integrated on a charmed service mesh live in different Juju models, the Beacon charm cannot generate a correct authorization policy from a normal Juju cross-model relation alone. The `cross_model_mesh` interface (exposed as the `provide-cmr-mesh` and `require-cmr-mesh` endpoints) exists to fill that gap, and it introduces one constraint on how cross-model offers must be structured.
+The Beacon charm automatically generates authorization policies based on the juju integrations that are in place at a given time. But, when two applications integrated with one another live in different Juju models, the Beacon charm cannot generate a correct authorization policy from a normal Juju cross-model relation and the `service-mesh` relation alone. The `cross_model_mesh` interface (exposed as the `provide-cmr-mesh` and `require-cmr-mesh` endpoints) exists to fill that gap, and it introduces one constraint on how cross-model offers must be structured.
 
 ## Why a dedicated cross-model interface is needed
 
@@ -33,8 +33,7 @@ The same applies when multiple workload endpoints on a remote application each n
 juju offer my-app:reviews,metrics-endpoint,ingress,provide-cmr-mesh
 ```
 
-This is a structural limitation of Juju cross-model relations and cannot be worked around in the mesh charms or library. Future Juju support for surfacing the real remote application identity to the consumed side would remove the need for the `cross_model_mesh` interface and this grouping requirement.
-
+This is a structural limitation of Juju cross-model relations and cannot be worked around in the mesh charms or library.
 ## See also
 
 * [Use the Istio mesh across different Juju models](../tutorial/use-the-istio-mesh-across-different-juju-models.md): tutorial walkthrough of a cross-model mesh setup.

--- a/docs/explanation/cross-model-mesh.md
+++ b/docs/explanation/cross-model-mesh.md
@@ -15,7 +15,7 @@ The `cross_model_mesh` interface works around this by carrying the real `app_nam
 
 ## How the correlation works
 
-When Beacon builds policies, it iterates over each workload relation (for example `metrics-endpoint`, `reviews`, `ingress`) and, for each one, looks up the matching `cross_model_mesh` payload to discover the real source identity. The lookup key is the remote application as seen locally, that is, the local SAAS name on the relation.
+When Beacon builds policies, it iterates over each service-mesh relation (for example `metrics-endpoint`, `reviews`, `ingress`) and, for each one, looks up the matching `cross_model_mesh` relation to discover the real source identity. The lookup key is the remote application as seen locally, that is, the local SAAS name on the relation.
 
 This means the workload relation and the `cross_model_mesh` relation must arrive on the providing side under the **same** SAAS. Only then does the Beacon charm know that a given `cross_model_mesh` payload describes the source of a given workload relation.
 

--- a/docs/explanation/cross-model-mesh.md
+++ b/docs/explanation/cross-model-mesh.md
@@ -1,0 +1,41 @@
+# Cross-model mesh
+
+When two applications integrated on a charmed service mesh live in different Juju models, the Beacon charm cannot generate a correct authorization policy from a normal Juju cross-model relation alone. The `cross_model_mesh` interface (exposed as the `provide-cmr-mesh` and `require-cmr-mesh` endpoints) exists to fill that gap, and it introduces one constraint on how cross-model offers must be structured.
+
+## Why a dedicated cross-model interface is needed
+
+A service mesh authorization policy identifies the source of allowed traffic by the workload's real identity. For Istio, the principal is `cluster.local/ns/<remote-model>/sa/<remote-app>`. To build this principal, the Beacon charm in the providing model needs to know two things about the consuming application:
+
+* the **real application name** in the remote model
+* the **real model name** the remote application is deployed in
+
+Juju does not expose either of these across a cross-model relation. On the consumer side, an offer is consumed as a Software-as-a-Service (SAAS) under a local alias, and that local alias is the only name the providing side ever sees on the relation (`relation.app.name`). It has no relationship to the actual remote application name, and the remote model name is not surfaced at all.
+
+The `cross_model_mesh` interface works around this by carrying the real `app_name` and `juju_model_name` of the consuming application explicitly in its relation data. The Beacon charm reads this payload and uses it, instead of the local SAAS alias, to build the source principal of the generated `AuthorizationPolicy`.
+
+## How the correlation works
+
+When Beacon builds policies, it iterates over each workload relation (for example `metrics-endpoint`, `reviews`, `ingress`) and, for each one, looks up the matching `cross_model_mesh` payload to discover the real source identity. The lookup key is the remote application as seen locally, that is, the local SAAS name on the relation.
+
+This means the workload relation and the `cross_model_mesh` relation must arrive on the providing side under the **same** SAAS. Only then does the Beacon charm know that a given `cross_model_mesh` payload describes the source of a given workload relation.
+
+## Limitation: group cross-model endpoints into a single offer
+
+A Juju offer produces exactly one SAAS on the consumer side, and each SAAS in a consuming model must have a unique local name. As a direct consequence:
+
+> All endpoints of a remote application that require an authorization policy, together with the `provide-cmr-mesh` endpoint, must be exposed through a **single** Juju offer.
+
+If the workload endpoint and `provide-cmr-mesh` are exposed through separate offers, the consumer ends up with two different SAAS names backing the same remote application. The providing Beacon receives the two relations under two unrelated local names and cannot correlate them. The lookup silently falls back to the local SAAS alias as the source name, producing an `AuthorizationPolicy` whose source principal does not match any real workload. The policy is silently ineffective: cross-model traffic that should be allowed is denied (in hardened mode), or, if a permissive rule happens to match for unrelated reasons, granted under the wrong identity.
+
+The same applies when multiple workload endpoints on a remote application each need their own policy. They must all be grouped into the single offer that also exposes `provide-cmr-mesh`. For example:
+
+```bash
+juju offer my-app:reviews,metrics-endpoint,ingress,provide-cmr-mesh
+```
+
+This is a structural limitation of Juju cross-model relations and cannot be worked around in the mesh charms or library. Future Juju support for surfacing the real remote application identity to the consumed side would remove the need for the `cross_model_mesh` interface and this grouping requirement.
+
+## See also
+
+* [Use the Istio mesh across different Juju models](../tutorial/use-the-istio-mesh-across-different-juju-models.md): tutorial walkthrough of a cross-model mesh setup.
+* [Traffic authorization](./traffic-authorization.md): how authorization policies are generated in a charmed service mesh.

--- a/docs/explanation/istio.md
+++ b/docs/explanation/istio.md
@@ -26,5 +26,6 @@ It is implemented through the following charms:
 hardened-mode
 managed-mode
 traffic-authorization
+cross-model-mesh
 cilium-cni-compatibility
 ```

--- a/docs/how-to/add-mesh-support-to-your-charm.md
+++ b/docs/how-to/add-mesh-support-to-your-charm.md
@@ -126,6 +126,6 @@ juju relate my-db-provider:database my-db-consumer:database
 juju relate my-db-provider:provide-cmr-support my-db-consumer:require-cmr-support
 ```
 
-For a more detailed tutorial using cross-model integrations, follow the [Use Istio ambient across different Juju models](../tutorial/use-the-istio-mesh-across-different-juju-models.md) tutorial.
+For a more detailed tutorial using cross-model integrations, follow the [Use Istio ambient across different Juju models](../tutorial/use-the-istio-mesh-across-different-juju-models.md) tutorial. For a discussion of why this extra relation is required and how it constrains the way you must structure your cross-model offers, see [Cross-model mesh](../explanation/cross-model-mesh.md).
 
 [^1]: For a detailed explanation of exactly what is generated automatically, see [Authorization Policy Creation in Istio](../explanation/traffic-authorization.md)

--- a/docs/tutorial/use-the-istio-mesh-across-different-juju-models.md
+++ b/docs/tutorial/use-the-istio-mesh-across-different-juju-models.md
@@ -87,7 +87,7 @@ This command offers two relations:
 - **`provide-cmr-mesh`**: A service mesh relation that allows applications in other Juju models to make HTTP calls to this charm via the service mesh
 
 ```{warning}
-Every endpoint of `bookinfo-reviews-k8s` that needs an authorization policy must be exposed through the **same** Juju offer as `provide-cmr-mesh`. If `reviews` and `provide-cmr-mesh` are split across separate offers, the consumer will consume them as two different SAAS, and Charmed Istio will silently generate an ineffective authorization policy. See [Cross-model mesh](../explanation/cross-model-mesh.md) for details.
+Every endpoint of `bookinfo-reviews-k8s` that needs an authorization policy must be exposed through the **same** Juju offer as `provide-cmr-mesh`. If `reviews` and `provide-cmr-mesh` are split across separate offers, the consumer will consume them as two different SaaS, and Charmed Istio will silently generate an ineffective authorization policy. See [Cross-model mesh](../explanation/cross-model-mesh.md) for details.
 ```
 
 ### Step 6: consume and connect the reviews charm

--- a/docs/tutorial/use-the-istio-mesh-across-different-juju-models.md
+++ b/docs/tutorial/use-the-istio-mesh-across-different-juju-models.md
@@ -86,6 +86,10 @@ This command offers two relations:
 - **`reviews`**: The application-specific relation for connecting the frontend [`bookinfo-productpage-k8s`](https://charmhub.io/bookinfo-productpage-k8s) with the backend `bookinfo-reviews-k8s` charm
 - **`provide-cmr-mesh`**: A service mesh relation that allows applications in other Juju models to make HTTP calls to this charm via the service mesh
 
+```{warning}
+Every endpoint of `bookinfo-reviews-k8s` that needs an authorization policy must be exposed through the **same** Juju offer as `provide-cmr-mesh`. If `reviews` and `provide-cmr-mesh` are split across separate offers, the consumer will consume them as two different SAAS, and Charmed Istio will silently generate an ineffective authorization policy. See [Cross-model mesh](../explanation/cross-model-mesh.md) for details.
+```
+
 ### Step 6: consume and connect the reviews charm
 
 Switch back to the original `bookinfo` model, [consume](https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/consume/) the `bookinfo-reviews-k8s` charm from the `bookinfo-2` Juju model and establish the cross-model connections:


### PR DESCRIPTION
Adds an explanation as to why the `cross-model-mesh` interface is necessary and its limitations

Fixes https://github.com/canonical/istio-beacon-k8s-operator/issues/181