### PR TITLE
feat(rocks): migrate rocks into the monorepo

### DIFF
--- a/.github/workflows/rock-pull-request.yaml
+++ b/.github/workflows/rock-pull-request.yaml
@@ -1,0 +1,56 @@
+name: Rock Pull Requests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'track/**'
+    paths:
+      - 'rocks/**'
+
+permissions:
+  security-events: write
+  actions: read
+  contents: read
+
+jobs:
+  discover-rocks:
+    name: Discover changed rocks
+    runs-on: ubuntu-latest
+    outputs:
+      rocks: ${{ steps.matrix.outputs.rocks }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            pilot: rocks/istio-pilot-rock/**
+            ztunnel: rocks/istio-ztunnel-rock/**
+            cni: rocks/istio-install-cni-rock/**
+      - id: matrix
+        run: |
+          rocks='[]'
+          if [ "${{ steps.changes.outputs.pilot }}" = "true" ]; then
+            rocks=$(echo "$rocks" | jq -c '. + ["rocks/istio-pilot-rock"]')
+          fi
+          if [ "${{ steps.changes.outputs.ztunnel }}" = "true" ]; then
+            rocks=$(echo "$rocks" | jq -c '. + ["rocks/istio-ztunnel-rock"]')
+          fi
+          if [ "${{ steps.changes.outputs.cni }}" = "true" ]; then
+            rocks=$(echo "$rocks" | jq -c '. + ["rocks/istio-install-cni-rock"]')
+          fi
+          echo "rocks=$rocks" >> "$GITHUB_OUTPUT"
+
+  pull-request:
+    name: PR (${{ matrix.rock-path }})
+    needs: discover-rocks
+    if: ${{ needs.discover-rocks.outputs.rocks != '' && needs.discover-rocks.outputs.rocks != '[]' }}
+    strategy:
+      matrix:
+        rock-path: ${{ fromJSON(needs.discover-rocks.outputs.rocks) }}
+      fail-fast: false
+    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v2
+    with:
+      rock-path: ${{ matrix.rock-path }}
+    secrets: inherit

--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -1,0 +1,55 @@
+name: "Publish Rocks to GHCR:dev"
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+    paths:
+      - 'rocks/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  discover-rocks:
+    name: Discover changed rocks
+    runs-on: ubuntu-latest
+    outputs:
+      rocks: ${{ steps.matrix.outputs.rocks }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            pilot: rocks/istio-pilot-rock/**
+            ztunnel: rocks/istio-ztunnel-rock/**
+            cni: rocks/istio-install-cni-rock/**
+      - id: matrix
+        run: |
+          rocks='[]'
+          if [ "${{ steps.changes.outputs.pilot }}" = "true" ]; then
+            rocks=$(echo "$rocks" | jq -c '. + ["rocks/istio-pilot-rock"]')
+          fi
+          if [ "${{ steps.changes.outputs.ztunnel }}" = "true" ]; then
+            rocks=$(echo "$rocks" | jq -c '. + ["rocks/istio-ztunnel-rock"]')
+          fi
+          if [ "${{ steps.changes.outputs.cni }}" = "true" ]; then
+            rocks=$(echo "$rocks" | jq -c '. + ["rocks/istio-install-cni-rock"]')
+          fi
+          echo "rocks=$rocks" >> "$GITHUB_OUTPUT"
+
+  release-dev:
+    name: Release to GHCR (${{ matrix.rock-path }})
+    needs: discover-rocks
+    if: ${{ needs.discover-rocks.outputs.rocks != '' && needs.discover-rocks.outputs.rocks != '[]' }}
+    strategy:
+      matrix:
+        rock-path: ${{ fromJSON(needs.discover-rocks.outputs.rocks) }}
+      fail-fast: false
+    uses: canonical/observability/.github/workflows/rock-release-dev.yaml@v2
+    with:
+      rock-path: ${{ matrix.rock-path }}
+    secrets: inherit

--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -1,0 +1,51 @@
+name: Open a PR to OCI Factory
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+    paths:
+      - 'rocks/**'
+
+jobs:
+  discover-rocks:
+    name: Discover changed rocks
+    runs-on: ubuntu-latest
+    outputs:
+      rocks: ${{ steps.matrix.outputs.rocks }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            pilot: rocks/istio-pilot-rock/**
+            ztunnel: rocks/istio-ztunnel-rock/**
+            cni: rocks/istio-install-cni-rock/**
+      - id: matrix
+        run: |
+          rocks='[]'
+          if [ "${{ steps.changes.outputs.pilot }}" = "true" ]; then
+            rocks=$(echo "$rocks" | jq -c '. + ["rocks/istio-pilot-rock"]')
+          fi
+          if [ "${{ steps.changes.outputs.ztunnel }}" = "true" ]; then
+            rocks=$(echo "$rocks" | jq -c '. + ["rocks/istio-ztunnel-rock"]')
+          fi
+          if [ "${{ steps.changes.outputs.cni }}" = "true" ]; then
+            rocks=$(echo "$rocks" | jq -c '. + ["rocks/istio-install-cni-rock"]')
+          fi
+          echo "rocks=$rocks" >> "$GITHUB_OUTPUT"
+
+  release-oci-factory:
+    name: Release to OCI Factory (${{ matrix.rock-path }})
+    needs: discover-rocks
+    if: ${{ needs.discover-rocks.outputs.rocks != '' && needs.discover-rocks.outputs.rocks != '[]' }}
+    strategy:
+      matrix:
+        rock-path: ${{ fromJSON(needs.discover-rocks.outputs.rocks) }}
+      fail-fast: false
+    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@v2
+    with:
+      rock-path: ${{ matrix.rock-path }}
+    secrets: inherit

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -1,0 +1,25 @@
+name: Update Rocks
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * 1'
+
+jobs:
+  update:
+    name: Update (${{ matrix.rock-path }})
+    strategy:
+      matrix:
+        include:
+          - rock-path: rocks/istio-pilot-rock
+            source-repo: istio/istio
+          - rock-path: rocks/istio-ztunnel-rock
+            source-repo: istio/ztunnel
+          - rock-path: rocks/istio-install-cni-rock
+            source-repo: istio/istio
+      fail-fast: false
+    uses: canonical/observability/.github/workflows/rock-update.yaml@v2
+    with:
+      rock-path: ${{ matrix.rock-path }}
+      source-repo: ${{ matrix.source-repo }}
+    secrets: inherit

--- a/rocks/istio-install-cni-rock/.gitignore
+++ b/rocks/istio-install-cni-rock/.gitignore
@@ -1,0 +1,14 @@
+# Ignore all spread.yaml files
+*/*/spread.yaml
+
+# Except the one in the top-level directory
+!/spread.yaml
+
+# Ignore copied goss.yaml files in component version directories
+*/*/goss.yaml
+
+# Ignore rocks
+*.rock
+
+# Ignore sboms
+*.sbom.json

--- a/rocks/istio-install-cni-rock/1.28.6/rockcraft.yaml
+++ b/rocks/istio-install-cni-rock/1.28.6/rockcraft.yaml
@@ -1,0 +1,64 @@
+# Rock for [install-cni](https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni).
+# The purpose of this image is described [here](https://github.com/istio/istio/tree/master/cni#overview)
+
+name: istio-install-cni
+summary: Istio's install-cni in a rock
+description: "Installs Istio's cni plugin"
+version: "1.28.6"
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+services:
+  install-cni:
+    command: "/usr/local/bin/install-cni"
+    override: replace
+    startup: enabled
+    working-dir: /opt/cni/bin
+platforms:
+  amd64:
+environment:
+  # from https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni#L24.  Unclear
+  # why/if it is needed here.
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/cni/bin
+parts:
+  # [install-cni](https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni)
+  # build instructions lifted from the makefile [here](https://github.com/istio/istio/blob/master/Makefile.core.mk#L246)
+  istio-install-cni:
+    plugin: go
+    source: https://github.com/istio/istio
+    source-type: git
+    source-tag: "1.28.6"
+    build-snaps:
+      - go/1.24/candidate
+    override-build: |
+      GOOS=linux GOARCH=amd64 LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh ./out/linux_amd64/ -tags=agent,disable_pgv ./cni/cmd/istio-cni ./cni/cmd/install-cni
+
+      mkdir -p ${CRAFT_PART_INSTALL}/opt/cni/bin
+      cp out/linux_amd64/istio-cni ${CRAFT_PART_INSTALL}/opt/cni/bin
+
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/local/bin
+      cp out/linux_amd64/install-cni ${CRAFT_PART_INSTALL}/usr/local/bin
+  # install packages provided by the istio/iptables distroless image, which is a base for install-cni
+  # as seen [here](https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni).
+  # The base image is defined [here](https://github.com/istio/istio/blob/master/docker/iptables.yaml) using apko,
+  # which is a tool for making distroless-like images.  apko's package names do not directly map to those in apt,
+  # so a bit of inference is applied to the list below.
+  stage-dependency-packages:
+    plugin: nil
+    stage-packages:
+      - libc6 # glibc
+      - iptables # includes both iptables and ip6tables
+      - conntrack # libnetfilter_conntrack and libnfnetlink (and maybe libmnl?)
+      - gcc
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - istio-install-cni
+      - stage-dependency-packages
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/rocks/istio-install-cni-rock/1.28.6/spread/.extension
+++ b/rocks/istio-install-cni-rock/1.28.6/spread/.extension
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+usage() {
+    echo "usage: $(basename "$0") [command]"
+    echo "valid commands:"
+    echo "    allocate              Create a backend instance to run tests on"
+    echo "    discard               Destroy a backend instance used to run tests"
+    echo "    backend-prepare       Set up the system to run tests"
+    echo "    backend-restore       Restore the system after the tests ran"
+    echo "    backend-prepare-each  Prepare the system before each test"
+    echo "    backend-restore-each  Restore the system after each test run"
+}
+
+prepare() {
+    case "$SPREAD_SYSTEM" in
+    fedora*)
+        dnf update -y
+        dnf install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    debian*)
+        apt update
+        apt install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    ubuntu*)
+        apt update
+        ;;
+    esac
+
+    snap wait system seed.loaded
+    snap refresh --hold
+
+    if systemctl is-enabled unattended-upgrades.service; then
+        systemctl stop unattended-upgrades.service
+        systemctl mask unattended-upgrades.service
+    fi
+}
+
+restore() {
+    case "$SPREAD_SYSTEM" in
+    ubuntu* | debian*)
+        apt autoremove -y --purge
+        ;;
+    esac
+
+    rm -Rf "$PROJECT_PATH"
+    mkdir -p "$PROJECT_PATH"
+}
+
+prepare_each() {
+    true
+}
+
+restore_each() {
+    true
+}
+
+allocate_lxdvm() {
+    name=$(echo "$SPREAD_SYSTEM" | tr '[:punct:]' -)
+    system=$(echo "$SPREAD_SYSTEM" | tr / -)
+    if [[ "$system" =~ ^ubuntu- ]]; then
+        image="ubuntu:${system#ubuntu-}"
+    else
+        image="images:$(echo "$system" | tr - /)"
+    fi
+
+    VM_NAME="${VM_NAME:-spread-${name}-${RANDOM}}"
+    DISK="${DISK:-20}"
+    CPU="${CPU:-4}"
+    MEM="${MEM:-8}"
+
+    lxc launch --vm \
+        "${image}" \
+        "${VM_NAME}" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+    while ! lxc exec "${VM_NAME}" -- true &>/dev/null; do sleep 0.5; done
+    lxc exec "${VM_NAME}" -- sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    lxc exec "${VM_NAME}" -- bash -c "if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' > /etc/ssh/sshd_config.d/00-spread.conf; fi"
+    lxc exec "${VM_NAME}" -- bash -c "echo root:${SPREAD_PASSWORD} | sudo chpasswd || true"
+
+    # Print the instance address to stdout
+    ADDR=""
+    while [ -z "$ADDR" ]; do ADDR=$(lxc ls -f csv | grep "^${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1); done
+    echo "$ADDR" 1>&3
+}
+
+discard_lxdvm() {
+    instance_name="$(lxc ls -f csv | sed ':a;N;$!ba;s/(docker0)\n/(docker0) /' | grep "$SPREAD_SYSTEM_ADDRESS " | cut -f1 -d",")"
+    lxc delete -f "$instance_name"
+}
+
+allocate_ci() {
+    if [ -z "$CI" ]; then
+        echo "This backend is intended to be used only in CI systems."
+        exit 1
+    fi
+    sudo sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/00-spread.conf; fi
+    sudo systemctl daemon-reload
+    sudo systemctl restart ssh
+
+    echo "root:${SPREAD_PASSWORD}" | sudo chpasswd || true
+
+    # Print the instance address to stdout
+    echo localhost >&3
+}
+
+discard_ci() {
+    true
+}
+
+allocate() {
+    exec 3>&1
+    exec 1>&2
+
+    case "$1" in
+    lxd-vm)
+        allocate_lxdvm
+        ;;
+    ci)
+        allocate_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+discard() {
+    case "$1" in
+    lxd-vm)
+        discard_lxdvm
+        ;;
+    ci)
+        discard_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+set -e
+
+while getopts "" o; do
+    case "${o}" in
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+CMD="$1"
+PARM="$2"
+
+if [ -z "$CMD" ]; then
+    usage
+    exit 0
+fi
+
+case "$CMD" in
+allocate)
+    allocate "$PARM"
+    ;;
+discard)
+    discard "$PARM"
+    ;;
+backend-prepare)
+    prepare
+    ;;
+backend-restore)
+    restore
+    ;;
+backend-prepare-each)
+    prepare_each
+    ;;
+backend-restore-each)
+    restore_each
+    ;;
+*)
+    echo "unknown command $CMD" >&2
+    ;;
+esac

--- a/rocks/istio-install-cni-rock/1.28.6/spread/general/ready/task.yaml
+++ b/rocks/istio-install-cni-rock/1.28.6/spread/general/ready/task.yaml
@@ -1,0 +1,7 @@
+summary: Run goss tests
+
+environment:
+  GOSS_FILE: "../../../goss.yaml"
+
+execute: |
+  dgoss run rockcraft-test:latest

--- a/rocks/istio-install-cni-rock/1.29.0/rockcraft.yaml
+++ b/rocks/istio-install-cni-rock/1.29.0/rockcraft.yaml
@@ -1,0 +1,64 @@
+# Rock for [install-cni](https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni).
+# The purpose of this image is described [here](https://github.com/istio/istio/tree/master/cni#overview)
+
+name: istio-install-cni
+summary: Istio's install-cni in a rock
+description: "Installs Istio's cni plugin"
+version: "1.29.0"
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+services:
+  install-cni:
+    command: "/usr/local/bin/install-cni"
+    override: replace
+    startup: enabled
+    working-dir: /opt/cni/bin
+platforms:
+  amd64:
+environment:
+  # from https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni#L24.  Unclear
+  # why/if it is needed here.
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/cni/bin
+parts:
+  # [install-cni](https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni)
+  # build instructions lifted from the makefile [here](https://github.com/istio/istio/blob/master/Makefile.core.mk#L246)
+  istio-install-cni:
+    plugin: go
+    source: https://github.com/istio/istio
+    source-type: git
+    source-tag: "1.29.0"
+    build-snaps:
+      - go/1.25/stable
+    override-build: |
+      VERSION=$CRAFT_PROJECT_VERSION GOOS=linux GOARCH=amd64 LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh ./out/linux_amd64/ -tags=agent,disable_pgv ./cni/cmd/istio-cni ./cni/cmd/install-cni
+
+      mkdir -p ${CRAFT_PART_INSTALL}/opt/cni/bin
+      cp out/linux_amd64/istio-cni ${CRAFT_PART_INSTALL}/opt/cni/bin
+
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/local/bin
+      cp out/linux_amd64/install-cni ${CRAFT_PART_INSTALL}/usr/local/bin
+  # install packages provided by the istio/iptables distroless image, which is a base for install-cni
+  # as seen [here](https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni).
+  # The base image is defined [here](https://github.com/istio/istio/blob/master/docker/iptables.yaml) using apko,
+  # which is a tool for making distroless-like images.  apko's package names do not directly map to those in apt,
+  # so a bit of inference is applied to the list below.
+  stage-dependency-packages:
+    plugin: nil
+    stage-packages:
+      - libc6 # glibc
+      - iptables # includes both iptables and ip6tables
+      - conntrack # libnetfilter_conntrack and libnfnetlink (and maybe libmnl?)
+      - gcc
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - istio-install-cni
+      - stage-dependency-packages
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/rocks/istio-install-cni-rock/1.29.0/spread/.extension
+++ b/rocks/istio-install-cni-rock/1.29.0/spread/.extension
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+usage() {
+    echo "usage: $(basename "$0") [command]"
+    echo "valid commands:"
+    echo "    allocate              Create a backend instance to run tests on"
+    echo "    discard               Destroy a backend instance used to run tests"
+    echo "    backend-prepare       Set up the system to run tests"
+    echo "    backend-restore       Restore the system after the tests ran"
+    echo "    backend-prepare-each  Prepare the system before each test"
+    echo "    backend-restore-each  Restore the system after each test run"
+}
+
+prepare() {
+    case "$SPREAD_SYSTEM" in
+    fedora*)
+        dnf update -y
+        dnf install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    debian*)
+        apt update
+        apt install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    ubuntu*)
+        apt update
+        ;;
+    esac
+
+    snap wait system seed.loaded
+    snap refresh --hold
+
+    if systemctl is-enabled unattended-upgrades.service; then
+        systemctl stop unattended-upgrades.service
+        systemctl mask unattended-upgrades.service
+    fi
+}
+
+restore() {
+    case "$SPREAD_SYSTEM" in
+    ubuntu* | debian*)
+        apt autoremove -y --purge
+        ;;
+    esac
+
+    rm -Rf "$PROJECT_PATH"
+    mkdir -p "$PROJECT_PATH"
+}
+
+prepare_each() {
+    true
+}
+
+restore_each() {
+    true
+}
+
+allocate_lxdvm() {
+    name=$(echo "$SPREAD_SYSTEM" | tr '[:punct:]' -)
+    system=$(echo "$SPREAD_SYSTEM" | tr / -)
+    if [[ "$system" =~ ^ubuntu- ]]; then
+        image="ubuntu:${system#ubuntu-}"
+    else
+        image="images:$(echo "$system" | tr - /)"
+    fi
+
+    VM_NAME="${VM_NAME:-spread-${name}-${RANDOM}}"
+    DISK="${DISK:-20}"
+    CPU="${CPU:-4}"
+    MEM="${MEM:-8}"
+
+    lxc launch --vm \
+        "${image}" \
+        "${VM_NAME}" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+    while ! lxc exec "${VM_NAME}" -- true &>/dev/null; do sleep 0.5; done
+    lxc exec "${VM_NAME}" -- sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    lxc exec "${VM_NAME}" -- bash -c "if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' > /etc/ssh/sshd_config.d/00-spread.conf; fi"
+    lxc exec "${VM_NAME}" -- bash -c "echo root:${SPREAD_PASSWORD} | sudo chpasswd || true"
+
+    # Print the instance address to stdout
+    ADDR=""
+    while [ -z "$ADDR" ]; do ADDR=$(lxc ls -f csv | grep "^${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1); done
+    echo "$ADDR" 1>&3
+}
+
+discard_lxdvm() {
+    instance_name="$(lxc ls -f csv | sed ':a;N;$!ba;s/(docker0)\n/(docker0) /' | grep "$SPREAD_SYSTEM_ADDRESS " | cut -f1 -d",")"
+    lxc delete -f "$instance_name"
+}
+
+allocate_ci() {
+    if [ -z "$CI" ]; then
+        echo "This backend is intended to be used only in CI systems."
+        exit 1
+    fi
+    sudo sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/00-spread.conf; fi
+    sudo systemctl daemon-reload
+    sudo systemctl restart ssh
+
+    echo "root:${SPREAD_PASSWORD}" | sudo chpasswd || true
+
+    # Print the instance address to stdout
+    echo localhost >&3
+}
+
+discard_ci() {
+    true
+}
+
+allocate() {
+    exec 3>&1
+    exec 1>&2
+
+    case "$1" in
+    lxd-vm)
+        allocate_lxdvm
+        ;;
+    ci)
+        allocate_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+discard() {
+    case "$1" in
+    lxd-vm)
+        discard_lxdvm
+        ;;
+    ci)
+        discard_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+set -e
+
+while getopts "" o; do
+    case "${o}" in
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+CMD="$1"
+PARM="$2"
+
+if [ -z "$CMD" ]; then
+    usage
+    exit 0
+fi
+
+case "$CMD" in
+allocate)
+    allocate "$PARM"
+    ;;
+discard)
+    discard "$PARM"
+    ;;
+backend-prepare)
+    prepare
+    ;;
+backend-restore)
+    restore
+    ;;
+backend-prepare-each)
+    prepare_each
+    ;;
+backend-restore-each)
+    restore_each
+    ;;
+*)
+    echo "unknown command $CMD" >&2
+    ;;
+esac

--- a/rocks/istio-install-cni-rock/1.29.0/spread/general/ready/task.yaml
+++ b/rocks/istio-install-cni-rock/1.29.0/spread/general/ready/task.yaml
@@ -1,0 +1,7 @@
+summary: Run goss tests
+
+environment:
+  GOSS_FILE: "../../../goss.yaml"
+
+execute: |
+  dgoss run rockcraft-test:latest

--- a/rocks/istio-install-cni-rock/1.30.0/rockcraft.yaml
+++ b/rocks/istio-install-cni-rock/1.30.0/rockcraft.yaml
@@ -1,0 +1,64 @@
+# Rock for [install-cni](https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni).
+# The purpose of this image is described [here](https://github.com/istio/istio/tree/master/cni#overview)
+
+name: istio-install-cni
+summary: Istio's install-cni in a rock
+description: "Installs Istio's cni plugin"
+version: "1.30.0"
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+services:
+  install-cni:
+    command: "/usr/local/bin/install-cni"
+    override: replace
+    startup: enabled
+    working-dir: /opt/cni/bin
+platforms:
+  amd64:
+environment:
+  # from https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni#L24.  Unclear
+  # why/if it is needed here.
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/cni/bin
+parts:
+  # [install-cni](https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni)
+  # build instructions lifted from the makefile [here](https://github.com/istio/istio/blob/master/Makefile.core.mk#L246)
+  istio-install-cni:
+    plugin: go
+    source: https://github.com/istio/istio
+    source-type: git
+    source-tag: "1.30.0"
+    build-snaps:
+      - go/1.25/candidate
+    override-build: |
+      GOOS=linux GOARCH=amd64 LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh ./out/linux_amd64/ -tags=agent,disable_pgv ./cni/cmd/istio-cni ./cni/cmd/install-cni
+
+      mkdir -p ${CRAFT_PART_INSTALL}/opt/cni/bin
+      cp out/linux_amd64/istio-cni ${CRAFT_PART_INSTALL}/opt/cni/bin
+
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/local/bin
+      cp out/linux_amd64/install-cni ${CRAFT_PART_INSTALL}/usr/local/bin
+  # install packages provided by the istio/iptables distroless image, which is a base for install-cni
+  # as seen [here](https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni).
+  # The base image is defined [here](https://github.com/istio/istio/blob/master/docker/iptables.yaml) using apko,
+  # which is a tool for making distroless-like images.  apko's package names do not directly map to those in apt,
+  # so a bit of inference is applied to the list below.
+  stage-dependency-packages:
+    plugin: nil
+    stage-packages:
+      - libc6 # glibc
+      - iptables # includes both iptables and ip6tables
+      - conntrack # libnetfilter_conntrack and libnfnetlink (and maybe libmnl?)
+      - gcc
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - istio-install-cni
+      - stage-dependency-packages
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/rocks/istio-install-cni-rock/1.30.0/spread/.extension
+++ b/rocks/istio-install-cni-rock/1.30.0/spread/.extension
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+usage() {
+    echo "usage: $(basename "$0") [command]"
+    echo "valid commands:"
+    echo "    allocate              Create a backend instance to run tests on"
+    echo "    discard               Destroy a backend instance used to run tests"
+    echo "    backend-prepare       Set up the system to run tests"
+    echo "    backend-restore       Restore the system after the tests ran"
+    echo "    backend-prepare-each  Prepare the system before each test"
+    echo "    backend-restore-each  Restore the system after each test run"
+}
+
+prepare() {
+    case "$SPREAD_SYSTEM" in
+    fedora*)
+        dnf update -y
+        dnf install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    debian*)
+        apt update
+        apt install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    ubuntu*)
+        apt update
+        ;;
+    esac
+
+    snap wait system seed.loaded
+    snap refresh --hold
+
+    if systemctl is-enabled unattended-upgrades.service; then
+        systemctl stop unattended-upgrades.service
+        systemctl mask unattended-upgrades.service
+    fi
+}
+
+restore() {
+    case "$SPREAD_SYSTEM" in
+    ubuntu* | debian*)
+        apt autoremove -y --purge
+        ;;
+    esac
+
+    rm -Rf "$PROJECT_PATH"
+    mkdir -p "$PROJECT_PATH"
+}
+
+prepare_each() {
+    true
+}
+
+restore_each() {
+    true
+}
+
+allocate_lxdvm() {
+    name=$(echo "$SPREAD_SYSTEM" | tr '[:punct:]' -)
+    system=$(echo "$SPREAD_SYSTEM" | tr / -)
+    if [[ "$system" =~ ^ubuntu- ]]; then
+        image="ubuntu:${system#ubuntu-}"
+    else
+        image="images:$(echo "$system" | tr - /)"
+    fi
+
+    VM_NAME="${VM_NAME:-spread-${name}-${RANDOM}}"
+    DISK="${DISK:-20}"
+    CPU="${CPU:-4}"
+    MEM="${MEM:-8}"
+
+    lxc launch --vm \
+        "${image}" \
+        "${VM_NAME}" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+    while ! lxc exec "${VM_NAME}" -- true &>/dev/null; do sleep 0.5; done
+    lxc exec "${VM_NAME}" -- sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    lxc exec "${VM_NAME}" -- bash -c "if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' > /etc/ssh/sshd_config.d/00-spread.conf; fi"
+    lxc exec "${VM_NAME}" -- bash -c "echo root:${SPREAD_PASSWORD} | sudo chpasswd || true"
+
+    # Print the instance address to stdout
+    ADDR=""
+    while [ -z "$ADDR" ]; do ADDR=$(lxc ls -f csv | grep "^${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1); done
+    echo "$ADDR" 1>&3
+}
+
+discard_lxdvm() {
+    instance_name="$(lxc ls -f csv | sed ':a;N;$!ba;s/(docker0)\n/(docker0) /' | grep "$SPREAD_SYSTEM_ADDRESS " | cut -f1 -d",")"
+    lxc delete -f "$instance_name"
+}
+
+allocate_ci() {
+    if [ -z "$CI" ]; then
+        echo "This backend is intended to be used only in CI systems."
+        exit 1
+    fi
+    sudo sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/00-spread.conf; fi
+    sudo systemctl daemon-reload
+    sudo systemctl restart ssh
+
+    echo "root:${SPREAD_PASSWORD}" | sudo chpasswd || true
+
+    # Print the instance address to stdout
+    echo localhost >&3
+}
+
+discard_ci() {
+    true
+}
+
+allocate() {
+    exec 3>&1
+    exec 1>&2
+
+    case "$1" in
+    lxd-vm)
+        allocate_lxdvm
+        ;;
+    ci)
+        allocate_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+discard() {
+    case "$1" in
+    lxd-vm)
+        discard_lxdvm
+        ;;
+    ci)
+        discard_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+set -e
+
+while getopts "" o; do
+    case "${o}" in
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+CMD="$1"
+PARM="$2"
+
+if [ -z "$CMD" ]; then
+    usage
+    exit 0
+fi
+
+case "$CMD" in
+allocate)
+    allocate "$PARM"
+    ;;
+discard)
+    discard "$PARM"
+    ;;
+backend-prepare)
+    prepare
+    ;;
+backend-restore)
+    restore
+    ;;
+backend-prepare-each)
+    prepare_each
+    ;;
+backend-restore-each)
+    restore_each
+    ;;
+*)
+    echo "unknown command $CMD" >&2
+    ;;
+esac

--- a/rocks/istio-install-cni-rock/1.30.0/spread/general/ready/task.yaml
+++ b/rocks/istio-install-cni-rock/1.30.0/spread/general/ready/task.yaml
@@ -1,0 +1,7 @@
+summary: Run goss tests
+
+environment:
+  GOSS_FILE: "../../../goss.yaml"
+
+execute: |
+  dgoss run rockcraft-test:latest

--- a/rocks/istio-install-cni-rock/CODEOWNERS
+++ b/rocks/istio-install-cni-rock/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/service-mesh 

--- a/rocks/istio-install-cni-rock/LICENSE
+++ b/rocks/istio-install-cni-rock/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/rocks/istio-install-cni-rock/README.md
+++ b/rocks/istio-install-cni-rock/README.md
@@ -1,0 +1,16 @@
+# istio-install-cni-rock
+
+[![Open a PR to OCI Factory](https://github.com/canonical/istio-install-cni-rock/actions/workflows/release-oci-factory.yaml/badge.svg)](https://github.com/canonical/istio-install-cni-rock/actions/workflows/release-oci-factory.yaml)
+[![Publish to GHCR:dev](https://github.com/canonical/istio-install-cni-rock/actions/workflows/release-dev.yaml/badge.svg)](https://github.com/canonical/istio-install-cni-rock/actions/workflows/release-dev.yaml)
+[![Update rock](https://github.com/canonical/istio-install-cni-rock/actions/workflows/update.yaml/badge.svg)](https://github.com/canonical/istio-install-cni-rock/actions/workflows/update.yaml)
+
+A [rock](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/) for [Istio's](https://istio.io/) [install-cni](https://hub.docker.com/r/istio/install-cni) image, which is defined [here](https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni).  This image is for installing Istio's CNI plugin, which is used for Istio's ambient mesh, and is described more [here](https://github.com/istio/istio/tree/master/cni#overview).
+
+This repository holds all the necessary files to build a rock for the upstream versions we support. The rock is used indirectly by the [istio-k8s-operator](https://github.com/canonical/istio-k8s-operator/) charm.
+
+The rocks on this repository are built with [OCI Factory](https://github.com/canonical/oci-factory/), which also takes care of periodically rebuilding the images.
+
+Automation takes care of:
+* validating PRs, by simply trying to build the rock;
+* pulling upstream releases, creating a PR with the necessary files to be manually reviewed;
+* releasing to GHCR at [ghcr.io/canonical/istio-install-cni:dev](https://ghcr.io/canonical/istio-install-cni:dev), when merging to main, for development purposes.

--- a/rocks/istio-install-cni-rock/goss.yaml
+++ b/rocks/istio-install-cni-rock/goss.yaml
@@ -1,0 +1,4 @@
+# TODO: write some actual goss tests
+command:
+  true:
+    exit-status: 0

--- a/rocks/istio-install-cni-rock/justfile
+++ b/rocks/istio-install-cni-rock/justfile
@@ -1,0 +1,9 @@
+set allow-duplicate-recipes
+set allow-duplicate-variables
+import? 'rocks.just'
+
+[private]
+@default:
+  just --list
+  echo ""
+  echo "For help with a specific recipe, run: just --usage <recipe>"

--- a/rocks/istio-install-cni-rock/rocks.just
+++ b/rocks/istio-install-cni-rock/rocks.just
@@ -1,0 +1,224 @@
+# Centralized justfile for the Canonical Observability rocks
+set shell := ["bash", "-uc"]
+
+rock_name := `echo ${PWD##*/} | sed 's/-rock$//'`  # Get the rock name from the folder name
+latest_version := `find . -name rockcraft.yaml -printf '%h\n' | sort -V | tail -n1 | sed 's@./@@'`
+
+# LTS end-of-life overrides. Override this variable in the local 'justfile'.
+# Define mappings from LTS minor versions to their EOL date in YYYY-MM-DD format.
+# Example: lts_releases := '{"2.14": "2026-12-31", "2.12": "2025-06-30"}'
+lts_releases := '{}'
+
+[private]
+@default:
+  just --list
+  echo "{{rock_name}}"
+  echo "For help with a specific recipe, run: just --usage <recipe>"
+
+# Push an OCI image to a local registry
+[private]
+@push-to-registry version=latest_version:
+  which -s docker || { echo "docker not found"; exit 1; }
+  test -f "{{version}}/{{rock_name}}_{{version}}_amd64.rock" || rockcraft pack
+  echo "Pushing {{version}} to local docker registry"
+  cd {{version}}; sudo rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false "oci-archive:{{rock_name}}_{{version}}_amd64.rock" docker-daemon:rockcraft-test:latest
+  echo "✓ Rock pushed to local registry under 'rockcraft-test:latest'"
+
+# Print the rock name
+[group("info")]
+@name:
+  echo "{{rock_name}}"
+
+# Print the latest rock version
+[group("info")]
+@latest-version:
+  echo "{{latest_version}}"
+
+# Pack a rock of a specific component and version
+[group("dev")]
+pack version=latest_version:
+  cd "{{version}}" && rockcraft pack
+
+# `rockcraft clean` for a specific component and version
+[group("dev")]
+clean version=latest_version:
+  cd "{{version}}" && rockcraft clean
+
+# Run a rock and open a shell into it with `docker`
+[group("dev")]
+run version=latest_version: (push-to-registry version)
+  which -s dgoss || { echo "dgoss not found"; exit 1; }
+  dgoss edit rockcraft-test:latest || true
+
+# Test a rock with `rockcraft test`
+[group("dev")]
+test version=latest_version:
+  #!/usr/bin/env bash
+  set -e
+  cp spread.yaml "{{version}}/spread.yaml"
+  if [ -f goss.yaml ]; then cp goss.yaml "{{version}}/goss.yaml"; fi
+  test_exit=0; (cd "{{version}}" && rockcraft test) || test_exit=$?
+  rm -f "{{version}}/spread.yaml" "{{version}}/goss.yaml"
+  if [ "$test_exit" -ne 0 ]; then echo "× rockcraft test failed"; exit "$test_exit"; fi
+  echo "✓ 'rockcraft test' passed."
+
+# Generate SBOM for the rock
+[group("security")]
+sbom version=latest_version:
+  syft {{version}}/*.rock -o "spdx-json={{version}}/rock.sbom.json"
+  @echo "✓ SBOM saved to {{version}}/rock.sbom.json"
+
+# Perform a securiy scan
+[group("security")]
+scan version=latest_version: (sbom version)
+  uvx --from=trivy-py trivy sbom "{{version}}/rock.sbom.json"
+  @echo "✓ Vulnerability scan done"
+
+# Check whether CVEs affect the upstream project
+[group("security")]
+govulncheck source_repo version=latest_version:
+  #!/usr/bin/env bash
+  set -e
+  echo "Cloning {{source_repo}}"
+  which -s govulncheck || { echo "govulncheck not found; install it with:  go install golang.org/x/vuln/cmd/govulncheck@latest"; exit 1; }
+  TMP_DIR="$(mktemp -d)"
+  gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "{{version}}" --depth 1 2>/dev/null \
+    || gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "v{{version}}" --depth 1
+  if [[ ! -f "$TMP_DIR/{{source_repo}}/go.mod" ]]; then
+    echo "⨯ {{source_repo}} is not a Go project (go.mod is missing)"
+    exit 2
+  fi
+  echo "Running 'govulncheck' (this may take a while)"
+  vuln_exit=0; (cd "$TMP_DIR/{{source_repo}}" && govulncheck ./...) || vuln_exit=$?
+  rm -rf "$TMP_DIR"
+  if [ "$vuln_exit" -ne 0 ]; then echo "⨯ 'govulncheck' failed"; exit "$vuln_exit"; fi
+  echo "✓ 'govulncheck' passed."
+
+# Generate a rock for the latest version of the upstream project
+[arg("source_repo", help="Repository of the upstream project in 'org/repo' form")]
+[group("maintenance")]
+update source_repo release_tag="":
+  #!/usr/bin/env bash
+  set -e
+  if [[ -z "{{release_tag}}" ]]; then
+    latest_release="$(gh release list --repo {{source_repo}} --exclude-pre-releases --limit=1 --json tagName --jq '.[0].tagName')"
+    echo "Latest release for {{source_repo}} is $latest_release"
+  else
+    latest_release="{{release_tag}}"
+    echo "Release version manually set to $latest_release"
+  fi
+  # Explicitly filter out prefixes for known rocks, so we can notice if a new rock has a different schema
+  version="${latest_release}"
+  version="${version#mimir-}"  # mimir
+  version="${version#cmd/builder/v}"  # opentelemetry-collector
+  version="${version#v}"  # Generic v- prefix
+  # If the version already exists as a rock, exit here
+  if [[ -d "$version" ]]; then echo "Folder $version already exists, nothing to do" && exit 0; fi
+  # Create the folder for the new version and update the rockcraft.yaml
+  cp -r "{{latest_version}}" "$version"
+  latest_release="$latest_release" version="$version" yq -i \
+    '.version = strenv(version) | .parts.{{rock_name}}["source-tag"] = strenv(latest_release)' \
+    "./$version/rockcraft.yaml"
+  # Automatically update build tools (go) from the upstream repository
+  TMP_DIR="$(mktemp -d)"
+  gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "$latest_release" --depth 1
+  # If it's a Go project, update the Go version
+  if [[ -f "$TMP_DIR/{{source_repo}}/go.mod" ]]; then
+    go_snap_version="$(grep -Po '^go \K(\S+)' "$TMP_DIR/{{source_repo}}/go.mod" | sed -E 's/([0-9]+\.[0-9]+).*/\1/')"
+    go_snap_version="$go_snap_version" yq -i \
+      '(.parts.{{rock_name}}.build-snaps[] | select(test("^go/"))) = "go/"+strenv(go_snap_version)+"/candidate"' \
+      "./$version/rockcraft.yaml"
+  fi
+  rm -rf "$TMP_DIR"
+  echo "✓ Created rock for version $version"
+
+# Fetch centralized files from canonical/observability
+[group("maintenance")]
+refresh:
+  #!/usr/bin/env bash
+  which -s gh || { echo "gh not found"; exit 1; }
+  refresh_folder="blueprints/rocks"
+  api_path="repos/canonical/observability/contents/$refresh_folder"
+  for file in rocks.just spread.yaml; do
+    echo "Fetching latest '$file' from canonical/observability ..."
+    gh api "$api_path/$file" --jq '.content' | base64 --decode > "$file"
+    echo "✓ $file updated"
+  done
+
+# Release rock to GHCR with tag `:dev`
+[group("release")]
+release-ghcr version=latest_version github_user="observability-noctua-bot":
+  #!/usr/bin/env bash
+  set -e
+  if [[ -z "$GITHUB_TOKEN" ]]; then echo "× Please export GITHUB_TOKEN for the user {{github_user}}"; exit 1; fi
+  if [ ! -e {{version}}/*.rock ]; then echo "× Error: rock not found. Please run 'just pack {{version}}' first."; exit 2; fi
+  sudo rockcraft.skopeo --insecure-policy copy \
+    "oci-archive:$(realpath ./{{version}}/*.rock)" \
+    "docker://ghcr.io/canonical/{{rock_name}}:dev" \
+    --dest-creds "{{github_user}}:${GITHUB_TOKEN}"
+  echo "✓ {{rock_name}} {{version}} pushed to GHCR with tag ':dev'"
+
+# Open a PR to OCI Factory
+[group("release")]
+[arg("support",pattern="major|minor|patch")]
+[arg("risk", pattern="stable|candidate|beta|edge")]
+release-oci-factory version=latest_version support="minor" risk="stable":
+  #!/usr/bin/env bash
+  set -e
+  if [[ -z "$GITHUB_TOKEN" ]]; then echo "× Please export GITHUB_TOKEN for the user observability-noctua-bot"; exit 1; fi
+  if [ ! -e {{version}}/*.rock ]; then echo "× Error: rock not found. Please run 'just pack {{version}}' first."; exit 2; fi
+  repository="$(git remote get-url origin | sed -E 's#(git@[^:]+:|https?://[^/]+/)##; s/\.git$//')"
+  # Extract the base from the rockcraft.yaml (e.g. "ubuntu@24.04" -> "24.04")
+  rock_base="$(yq -r '.base' "{{version}}/rockcraft.yaml" | sed 's/.*@//')"
+  echo "Detected base: $rock_base"
+  # Clone the oci-factory and push data to it
+  gh repo sync --force observability-noctua-bot/oci-factory
+  TMP_DIR="$(mktemp -d)"
+  git clone https://github.com/observability-noctua-bot/oci-factory "$TMP_DIR/oci-factory"
+  echo "✓ Cloned observability-noctua-bot/oci-factory"
+  # Build the OCI Factory manifest
+  # Check if this version has a custom EOL in lts_releases
+  minor_version="$(echo "{{version}}" | grep -oP '^\d+\.\d+')"
+  eol_date="$(echo '{{lts_releases}}' | jq -r --arg v "$minor_version" '.[$v] // empty')"
+  eol_flag=""
+  if [[ -n "$eol_date" ]]; then
+    eol_flag="--eol=$eol_date"
+    echo "LTS release detected: EOL set to $eol_date"
+  fi
+  echo "Building the OCI Factory manifest..."; echo
+  manifest_file="$TMP_DIR/oci-factory/oci/{{rock_name}}/image.yaml"
+  uvx --from=git+https://github.com/lucabello/noctua noctua rock manifest \
+    "$repository" \
+    --commit="$(git rev-parse HEAD)" \
+    --base="$rock_base" \
+    --support="{{support}}" \
+    --risk="{{risk}}" \
+    --version="{{version}}" \
+    $eol_flag \
+    | tee "$manifest_file"
+  echo; echo "✓ OCI Factory manifest generated"
+  # If there's nothing to upload, exit early
+  upload_count="$(cat "$manifest_file" | yq '.upload | length')"
+  if [[ "$upload_count" -eq 0 ]]; then
+    echo "✓ Nothing to update in OCI Factory"
+    rm -rf "$TMP_DIR"
+    exit 0
+  fi
+  # Commit the changes and create a PR
+  pushd "$TMP_DIR/oci-factory" >/dev/null
+  git config user.name observability-noctua-bot
+  git config user.email webops+observability-noctua-bot@canonical.com
+  git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/observability-noctua-bot/oci-factory.git"
+  branch_name="update-$(date -d now +%s)"
+  git checkout -b "$branch_name"
+  git add oci/{{rock_name}}/image.yaml
+  git commit -m "chore: Add new {{rock_name}} releases"
+  git push -u origin "$branch_name" --force
+  echo "✓ Changes have been pushed to ${branch_name}"
+  gh pr create --repo canonical/oci-factory \
+    --head "observability-noctua-bot:${branch_name}" \
+    --title "chore: Add new {{rock_name}} releases" \
+    --body "This is an automatic PR opened by the Observability Noctua bot."
+  popd >/dev/null
+  rm -rf "$TMP_DIR"
+  echo "✓ Release to OCI Factory completed"

--- a/rocks/istio-install-cni-rock/spread.yaml
+++ b/rocks/istio-install-cni-rock/spread.yaml
@@ -1,0 +1,41 @@
+project: rock
+
+backends:
+  craft:
+    type: craft
+    systems:
+      - ubuntu-24.04:
+      #- ubuntu-22.04:
+
+suites:
+  spread/general/:
+    summary: General integration tests
+    environment:
+      # Goss environment
+      GOSS_OPTS: "--retry-timeout=60s"
+      GOSS_FILES_STRATEGY: cp
+      DGOSS_TEMP_DIR: "$HOME"
+
+    prepare: |
+      # Install dependencies
+      sudo snap install docker
+      curl -fsSL https://goss.rocks/install | sh
+
+      # For 'rockcraft.skopeo'
+      sudo snap install --classic rockcraft
+
+      # Wait for docker daemon to come online
+      sudo apt install --yes retry
+      retry --times=10 --delay 2 -- docker run hello-world
+      sudo apt remove --yes retry
+
+      # Load the rock into docker
+      sudo rockcraft.skopeo --insecure-policy copy "oci-archive:$CRAFT_ARTIFACT" docker-daemon:rockcraft-test:latest
+      
+    restore: |
+      docker image rm --force rockcraft-test:latest
+
+exclude:
+  - .git
+
+kill-timeout: 1h

--- a/rocks/istio-pilot-rock/.gitignore
+++ b/rocks/istio-pilot-rock/.gitignore
@@ -1,0 +1,14 @@
+# Ignore all spread.yaml files
+*/*/spread.yaml
+
+# Except the one in the top-level directory
+!/spread.yaml
+
+# Ignore copied goss.yaml files in component version directories
+*/*/goss.yaml
+
+# Ignore rocks
+*.rock
+
+# Ignore sboms
+*.sbom.json

--- a/rocks/istio-pilot-rock/1.28.6/rockcraft.yaml
+++ b/rocks/istio-pilot-rock/1.28.6/rockcraft.yaml
@@ -1,0 +1,43 @@
+# Rock for [pilot](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.pilot).
+# This rock is based on the `ubuntu@24.04` rock and includes the `ca-certificates` package for secure communication. The `pilot-discovery` service is configured to run the Pilot component of Istio's service mesh, which is responsible for managing and configuring the Envoy proxies that handle traffic within the mesh. The rock also includes a `deb-security-manifest` part that generates a manifest of installed packages and their versions for security auditing purposes.
+
+name: istio-pilot
+summary: Istio's pilot in a rock
+description: "Pilot: The core component of Istio's service mesh"
+version: "1.28.6"
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+services:
+  pilot-discovery:
+    command: /usr/local/bin/pilot-discovery [ ]
+    override: replace
+    startup: enabled
+run-user: _daemon_
+entrypoint-service: pilot-discovery
+platforms:
+  amd64:
+parts:
+  # [pilot](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.pilot)
+  istio-pilot:
+    plugin: go
+    source: https://github.com/istio/istio
+    source-type: git
+    source-tag: "1.28.6"
+    build-snaps:
+      - go/1.24/candidate
+    override-build: |
+      VERSION=$CRAFT_PROJECT_VERSION GOOS=linux GOARCH=amd64 LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh ./out/linux_amd64/ -tags=vtprotobuf,disable_pgv ./pilot/cmd/pilot-discovery
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/local/bin
+      cp out/linux_amd64/pilot-discovery ${CRAFT_PART_INSTALL}/usr/local/bin
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - istio-pilot
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/rocks/istio-pilot-rock/1.28.6/spread/.extension
+++ b/rocks/istio-pilot-rock/1.28.6/spread/.extension
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+usage() {
+    echo "usage: $(basename "$0") [command]"
+    echo "valid commands:"
+    echo "    allocate              Create a backend instance to run tests on"
+    echo "    discard               Destroy a backend instance used to run tests"
+    echo "    backend-prepare       Set up the system to run tests"
+    echo "    backend-restore       Restore the system after the tests ran"
+    echo "    backend-prepare-each  Prepare the system before each test"
+    echo "    backend-restore-each  Restore the system after each test run"
+}
+
+prepare() {
+    case "$SPREAD_SYSTEM" in
+    fedora*)
+        dnf update -y
+        dnf install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    debian*)
+        apt update
+        apt install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    ubuntu*)
+        apt update
+        ;;
+    esac
+
+    snap wait system seed.loaded
+    snap refresh --hold
+
+    if systemctl is-enabled unattended-upgrades.service; then
+        systemctl stop unattended-upgrades.service
+        systemctl mask unattended-upgrades.service
+    fi
+}
+
+restore() {
+    case "$SPREAD_SYSTEM" in
+    ubuntu* | debian*)
+        apt autoremove -y --purge
+        ;;
+    esac
+
+    rm -Rf "$PROJECT_PATH"
+    mkdir -p "$PROJECT_PATH"
+}
+
+prepare_each() {
+    true
+}
+
+restore_each() {
+    true
+}
+
+allocate_lxdvm() {
+    name=$(echo "$SPREAD_SYSTEM" | tr '[:punct:]' -)
+    system=$(echo "$SPREAD_SYSTEM" | tr / -)
+    if [[ "$system" =~ ^ubuntu- ]]; then
+        image="ubuntu:${system#ubuntu-}"
+    else
+        image="images:$(echo "$system" | tr - /)"
+    fi
+
+    VM_NAME="${VM_NAME:-spread-${name}-${RANDOM}}"
+    DISK="${DISK:-20}"
+    CPU="${CPU:-4}"
+    MEM="${MEM:-8}"
+
+    lxc launch --vm \
+        "${image}" \
+        "${VM_NAME}" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+    while ! lxc exec "${VM_NAME}" -- true &>/dev/null; do sleep 0.5; done
+    lxc exec "${VM_NAME}" -- sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    lxc exec "${VM_NAME}" -- bash -c "if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' > /etc/ssh/sshd_config.d/00-spread.conf; fi"
+    lxc exec "${VM_NAME}" -- bash -c "echo root:${SPREAD_PASSWORD} | sudo chpasswd || true"
+
+    # Print the instance address to stdout
+    ADDR=""
+    while [ -z "$ADDR" ]; do ADDR=$(lxc ls -f csv | grep "^${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1); done
+    echo "$ADDR" 1>&3
+}
+
+discard_lxdvm() {
+    instance_name="$(lxc ls -f csv | sed ':a;N;$!ba;s/(docker0)\n/(docker0) /' | grep "$SPREAD_SYSTEM_ADDRESS " | cut -f1 -d",")"
+    lxc delete -f "$instance_name"
+}
+
+allocate_ci() {
+    if [ -z "$CI" ]; then
+        echo "This backend is intended to be used only in CI systems."
+        exit 1
+    fi
+    sudo sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/00-spread.conf; fi
+    sudo systemctl daemon-reload
+    sudo systemctl restart ssh
+
+    echo "root:${SPREAD_PASSWORD}" | sudo chpasswd || true
+
+    # Print the instance address to stdout
+    echo localhost >&3
+}
+
+discard_ci() {
+    true
+}
+
+allocate() {
+    exec 3>&1
+    exec 1>&2
+
+    case "$1" in
+    lxd-vm)
+        allocate_lxdvm
+        ;;
+    ci)
+        allocate_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+discard() {
+    case "$1" in
+    lxd-vm)
+        discard_lxdvm
+        ;;
+    ci)
+        discard_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+set -e
+
+while getopts "" o; do
+    case "${o}" in
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+CMD="$1"
+PARM="$2"
+
+if [ -z "$CMD" ]; then
+    usage
+    exit 0
+fi
+
+case "$CMD" in
+allocate)
+    allocate "$PARM"
+    ;;
+discard)
+    discard "$PARM"
+    ;;
+backend-prepare)
+    prepare
+    ;;
+backend-restore)
+    restore
+    ;;
+backend-prepare-each)
+    prepare_each
+    ;;
+backend-restore-each)
+    restore_each
+    ;;
+*)
+    echo "unknown command $CMD" >&2
+    ;;
+esac

--- a/rocks/istio-pilot-rock/1.28.6/spread/general/ready/task.yaml
+++ b/rocks/istio-pilot-rock/1.28.6/spread/general/ready/task.yaml
@@ -1,0 +1,7 @@
+summary: Run goss tests
+
+environment:
+  GOSS_FILE: "../../../goss.yaml"
+
+execute: |
+  dgoss run rockcraft-test:latest

--- a/rocks/istio-pilot-rock/1.29.0/rockcraft.yaml
+++ b/rocks/istio-pilot-rock/1.29.0/rockcraft.yaml
@@ -1,0 +1,43 @@
+# Rock for [pilot](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.pilot).
+# This rock is based on the `ubuntu@24.04` rock and includes the `ca-certificates` package for secure communication. The `pilot-discovery` service is configured to run the Pilot component of Istio's service mesh, which is responsible for managing and configuring the Envoy proxies that handle traffic within the mesh. The rock also includes a `deb-security-manifest` part that generates a manifest of installed packages and their versions for security auditing purposes.
+
+name: istio-pilot
+summary: Istio's pilot in a rock
+description: "Pilot: The core component of Istio's service mesh"
+version: "1.29.0"
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+services:
+  pilot-discovery:
+    command: /usr/local/bin/pilot-discovery [ ]
+    override: replace
+    startup: enabled
+run-user: _daemon_
+entrypoint-service: pilot-discovery
+platforms:
+  amd64:
+parts:
+  # [pilot](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.pilot)
+  istio-pilot:
+    plugin: go
+    source: https://github.com/istio/istio
+    source-type: git
+    source-tag: "1.29.0"
+    build-snaps:
+      - go/1.25/stable
+    override-build: |
+      VERSION=$CRAFT_PROJECT_VERSION GOOS=linux GOARCH=amd64 LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh ./out/linux_amd64/ -tags=vtprotobuf,disable_pgv ./pilot/cmd/pilot-discovery
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/local/bin
+      cp out/linux_amd64/pilot-discovery ${CRAFT_PART_INSTALL}/usr/local/bin
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - istio-pilot
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/rocks/istio-pilot-rock/1.29.0/spread/.extension
+++ b/rocks/istio-pilot-rock/1.29.0/spread/.extension
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+usage() {
+    echo "usage: $(basename "$0") [command]"
+    echo "valid commands:"
+    echo "    allocate              Create a backend instance to run tests on"
+    echo "    discard               Destroy a backend instance used to run tests"
+    echo "    backend-prepare       Set up the system to run tests"
+    echo "    backend-restore       Restore the system after the tests ran"
+    echo "    backend-prepare-each  Prepare the system before each test"
+    echo "    backend-restore-each  Restore the system after each test run"
+}
+
+prepare() {
+    case "$SPREAD_SYSTEM" in
+    fedora*)
+        dnf update -y
+        dnf install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    debian*)
+        apt update
+        apt install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    ubuntu*)
+        apt update
+        ;;
+    esac
+
+    snap wait system seed.loaded
+    snap refresh --hold
+
+    if systemctl is-enabled unattended-upgrades.service; then
+        systemctl stop unattended-upgrades.service
+        systemctl mask unattended-upgrades.service
+    fi
+}
+
+restore() {
+    case "$SPREAD_SYSTEM" in
+    ubuntu* | debian*)
+        apt autoremove -y --purge
+        ;;
+    esac
+
+    rm -Rf "$PROJECT_PATH"
+    mkdir -p "$PROJECT_PATH"
+}
+
+prepare_each() {
+    true
+}
+
+restore_each() {
+    true
+}
+
+allocate_lxdvm() {
+    name=$(echo "$SPREAD_SYSTEM" | tr '[:punct:]' -)
+    system=$(echo "$SPREAD_SYSTEM" | tr / -)
+    if [[ "$system" =~ ^ubuntu- ]]; then
+        image="ubuntu:${system#ubuntu-}"
+    else
+        image="images:$(echo "$system" | tr - /)"
+    fi
+
+    VM_NAME="${VM_NAME:-spread-${name}-${RANDOM}}"
+    DISK="${DISK:-20}"
+    CPU="${CPU:-4}"
+    MEM="${MEM:-8}"
+
+    lxc launch --vm \
+        "${image}" \
+        "${VM_NAME}" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+    while ! lxc exec "${VM_NAME}" -- true &>/dev/null; do sleep 0.5; done
+    lxc exec "${VM_NAME}" -- sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    lxc exec "${VM_NAME}" -- bash -c "if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' > /etc/ssh/sshd_config.d/00-spread.conf; fi"
+    lxc exec "${VM_NAME}" -- bash -c "echo root:${SPREAD_PASSWORD} | sudo chpasswd || true"
+
+    # Print the instance address to stdout
+    ADDR=""
+    while [ -z "$ADDR" ]; do ADDR=$(lxc ls -f csv | grep "^${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1); done
+    echo "$ADDR" 1>&3
+}
+
+discard_lxdvm() {
+    instance_name="$(lxc ls -f csv | sed ':a;N;$!ba;s/(docker0)\n/(docker0) /' | grep "$SPREAD_SYSTEM_ADDRESS " | cut -f1 -d",")"
+    lxc delete -f "$instance_name"
+}
+
+allocate_ci() {
+    if [ -z "$CI" ]; then
+        echo "This backend is intended to be used only in CI systems."
+        exit 1
+    fi
+    sudo sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/00-spread.conf; fi
+    sudo systemctl daemon-reload
+    sudo systemctl restart ssh
+
+    echo "root:${SPREAD_PASSWORD}" | sudo chpasswd || true
+
+    # Print the instance address to stdout
+    echo localhost >&3
+}
+
+discard_ci() {
+    true
+}
+
+allocate() {
+    exec 3>&1
+    exec 1>&2
+
+    case "$1" in
+    lxd-vm)
+        allocate_lxdvm
+        ;;
+    ci)
+        allocate_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+discard() {
+    case "$1" in
+    lxd-vm)
+        discard_lxdvm
+        ;;
+    ci)
+        discard_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+set -e
+
+while getopts "" o; do
+    case "${o}" in
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+CMD="$1"
+PARM="$2"
+
+if [ -z "$CMD" ]; then
+    usage
+    exit 0
+fi
+
+case "$CMD" in
+allocate)
+    allocate "$PARM"
+    ;;
+discard)
+    discard "$PARM"
+    ;;
+backend-prepare)
+    prepare
+    ;;
+backend-restore)
+    restore
+    ;;
+backend-prepare-each)
+    prepare_each
+    ;;
+backend-restore-each)
+    restore_each
+    ;;
+*)
+    echo "unknown command $CMD" >&2
+    ;;
+esac

--- a/rocks/istio-pilot-rock/1.29.0/spread/general/ready/task.yaml
+++ b/rocks/istio-pilot-rock/1.29.0/spread/general/ready/task.yaml
@@ -1,0 +1,7 @@
+summary: Run goss tests
+
+environment:
+  GOSS_FILE: "../../../goss.yaml"
+
+execute: |
+  dgoss run rockcraft-test:latest

--- a/rocks/istio-pilot-rock/1.30.0/rockcraft.yaml
+++ b/rocks/istio-pilot-rock/1.30.0/rockcraft.yaml
@@ -1,0 +1,43 @@
+# Rock for [pilot](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.pilot).
+# This rock is based on the `ubuntu@26.04` rock and includes the `ca-certificates` package for secure communication. The `pilot-discovery` service is configured to run the Pilot component of Istio's service mesh, which is responsible for managing and configuring the Envoy proxies that handle traffic within the mesh. The rock also includes a `deb-security-manifest` part that generates a manifest of installed packages and their versions for security auditing purposes.
+
+name: istio-pilot
+summary: Istio's pilot in a rock
+description: "Pilot: The core component of Istio's service mesh"
+version: "1.30.0"
+base: ubuntu@26.04
+build-base: ubuntu@26.04
+services:
+  pilot-discovery:
+    command: /usr/local/bin/pilot-discovery [ ]
+    override: replace
+    startup: enabled
+run-user: _daemon_
+entrypoint-service: pilot-discovery
+platforms:
+  amd64:
+parts:
+  # [pilot](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.pilot)
+  istio-pilot:
+    plugin: go
+    source: https://github.com/istio/istio
+    source-type: git
+    source-tag: "1.30.0"
+    build-snaps:
+      - go/1.25/candidate
+    override-build: |
+      VERSION=$CRAFT_PROJECT_VERSION GOOS=linux GOARCH=amd64 LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh ./out/linux_amd64/ -tags=vtprotobuf,disable_pgv ./pilot/cmd/pilot-discovery
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/local/bin
+      cp out/linux_amd64/pilot-discovery ${CRAFT_PART_INSTALL}/usr/local/bin
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - istio-pilot
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/rocks/istio-pilot-rock/1.30.0/spread/.extension
+++ b/rocks/istio-pilot-rock/1.30.0/spread/.extension
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+usage() {
+    echo "usage: $(basename "$0") [command]"
+    echo "valid commands:"
+    echo "    allocate              Create a backend instance to run tests on"
+    echo "    discard               Destroy a backend instance used to run tests"
+    echo "    backend-prepare       Set up the system to run tests"
+    echo "    backend-restore       Restore the system after the tests ran"
+    echo "    backend-prepare-each  Prepare the system before each test"
+    echo "    backend-restore-each  Restore the system after each test run"
+}
+
+prepare() {
+    case "$SPREAD_SYSTEM" in
+    fedora*)
+        dnf update -y
+        dnf install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    debian*)
+        apt update
+        apt install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    ubuntu*)
+        apt update
+        ;;
+    esac
+
+    snap wait system seed.loaded
+    snap refresh --hold
+
+    if systemctl is-enabled unattended-upgrades.service; then
+        systemctl stop unattended-upgrades.service
+        systemctl mask unattended-upgrades.service
+    fi
+}
+
+restore() {
+    case "$SPREAD_SYSTEM" in
+    ubuntu* | debian*)
+        apt autoremove -y --purge
+        ;;
+    esac
+
+    rm -Rf "$PROJECT_PATH"
+    mkdir -p "$PROJECT_PATH"
+}
+
+prepare_each() {
+    true
+}
+
+restore_each() {
+    true
+}
+
+allocate_lxdvm() {
+    name=$(echo "$SPREAD_SYSTEM" | tr '[:punct:]' -)
+    system=$(echo "$SPREAD_SYSTEM" | tr / -)
+    if [[ "$system" =~ ^ubuntu- ]]; then
+        image="ubuntu:${system#ubuntu-}"
+    else
+        image="images:$(echo "$system" | tr - /)"
+    fi
+
+    VM_NAME="${VM_NAME:-spread-${name}-${RANDOM}}"
+    DISK="${DISK:-20}"
+    CPU="${CPU:-4}"
+    MEM="${MEM:-8}"
+
+    lxc launch --vm \
+        "${image}" \
+        "${VM_NAME}" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+    while ! lxc exec "${VM_NAME}" -- true &>/dev/null; do sleep 0.5; done
+    lxc exec "${VM_NAME}" -- sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    lxc exec "${VM_NAME}" -- bash -c "if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' > /etc/ssh/sshd_config.d/00-spread.conf; fi"
+    lxc exec "${VM_NAME}" -- bash -c "echo root:${SPREAD_PASSWORD} | sudo chpasswd || true"
+
+    # Print the instance address to stdout
+    ADDR=""
+    while [ -z "$ADDR" ]; do ADDR=$(lxc ls -f csv | grep "^${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1); done
+    echo "$ADDR" 1>&3
+}
+
+discard_lxdvm() {
+    instance_name="$(lxc ls -f csv | sed ':a;N;$!ba;s/(docker0)\n/(docker0) /' | grep "$SPREAD_SYSTEM_ADDRESS " | cut -f1 -d",")"
+    lxc delete -f "$instance_name"
+}
+
+allocate_ci() {
+    if [ -z "$CI" ]; then
+        echo "This backend is intended to be used only in CI systems."
+        exit 1
+    fi
+    sudo sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/00-spread.conf; fi
+    sudo systemctl daemon-reload
+    sudo systemctl restart ssh
+
+    echo "root:${SPREAD_PASSWORD}" | sudo chpasswd || true
+
+    # Print the instance address to stdout
+    echo localhost >&3
+}
+
+discard_ci() {
+    true
+}
+
+allocate() {
+    exec 3>&1
+    exec 1>&2
+
+    case "$1" in
+    lxd-vm)
+        allocate_lxdvm
+        ;;
+    ci)
+        allocate_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+discard() {
+    case "$1" in
+    lxd-vm)
+        discard_lxdvm
+        ;;
+    ci)
+        discard_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+set -e
+
+while getopts "" o; do
+    case "${o}" in
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+CMD="$1"
+PARM="$2"
+
+if [ -z "$CMD" ]; then
+    usage
+    exit 0
+fi
+
+case "$CMD" in
+allocate)
+    allocate "$PARM"
+    ;;
+discard)
+    discard "$PARM"
+    ;;
+backend-prepare)
+    prepare
+    ;;
+backend-restore)
+    restore
+    ;;
+backend-prepare-each)
+    prepare_each
+    ;;
+backend-restore-each)
+    restore_each
+    ;;
+*)
+    echo "unknown command $CMD" >&2
+    ;;
+esac

--- a/rocks/istio-pilot-rock/1.30.0/spread/general/ready/task.yaml
+++ b/rocks/istio-pilot-rock/1.30.0/spread/general/ready/task.yaml
@@ -1,0 +1,7 @@
+summary: Run goss tests
+
+environment:
+  GOSS_FILE: "../../../goss.yaml"
+
+execute: |
+  dgoss run rockcraft-test:latest

--- a/rocks/istio-pilot-rock/CODEOWNERS
+++ b/rocks/istio-pilot-rock/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/service-mesh

--- a/rocks/istio-pilot-rock/LICENSE
+++ b/rocks/istio-pilot-rock/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Canonical
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/rocks/istio-pilot-rock/README.md
+++ b/rocks/istio-pilot-rock/README.md
@@ -1,0 +1,15 @@
+# istio-pilot-rock
+
+[![Open a PR to OCI Factory](https://github.com/canonical/istio-pilot-rock/actions/workflows/release-oci-factory.yaml/badge.svg)](https://github.com/canonical/istio-pilot-rock/actions/workflows/release-oci-factory.yaml)
+[![Publish to GHCR:dev](https://github.com/canonical/istio-pilot-rock/actions/workflows/release-dev.yaml/badge.svg)](https://github.com/canonical/istio-pilot-rock/actions/workflows/release-dev.yaml)
+[![Update rock](https://github.com/canonical/istio-pilot-rock/actions/workflows/update.yaml/badge.svg)](https://github.com/canonical/istio-pilot-rock/actions/workflows/update.yaml)
+
+A [rock](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/) for [Istio's](https://istio.io/) [pilot](https://hub.docker.com/r/istio/pilot) image.  
+This repository holds all the necessary files to build a rock for the upstream versions we support. The rock is used indirectly by the [istio-k8s-operator](https://github.com/canonical/istio-k8s-operator/) charm.
+
+The rocks on this repository are built with [OCI Factory](https://github.com/canonical/oci-factory/), which also takes care of periodically rebuilding the images.
+
+Automation takes care of:
+* validating PRs, by simply trying to build the rock;
+* pulling upstream releases, creating a PR with the necessary files to be manually reviewed;
+* releasing to GHCR at [ghcr.io/canonical/istio-pilot:dev](https://ghcr.io/canonical/istio-pilot:dev), when merging to main, for development purposes.

--- a/rocks/istio-pilot-rock/goss.yaml
+++ b/rocks/istio-pilot-rock/goss.yaml
@@ -1,0 +1,4 @@
+# TODO: write some actual goss tests
+command:
+  true:
+    exit-status: 0

--- a/rocks/istio-pilot-rock/justfile
+++ b/rocks/istio-pilot-rock/justfile
@@ -1,0 +1,9 @@
+set allow-duplicate-recipes
+set allow-duplicate-variables
+import? 'rocks.just'
+
+[private]
+@default:
+  just --list
+  echo ""
+  echo "For help with a specific recipe, run: just --usage <recipe>"

--- a/rocks/istio-pilot-rock/rocks.just
+++ b/rocks/istio-pilot-rock/rocks.just
@@ -1,0 +1,224 @@
+# Centralized justfile for the Canonical Observability rocks
+set shell := ["bash", "-uc"]
+
+rock_name := `echo ${PWD##*/} | sed 's/-rock$//'`  # Get the rock name from the folder name
+latest_version := `find . -name rockcraft.yaml -printf '%h\n' | sort -V | tail -n1 | sed 's@./@@'`
+
+# LTS end-of-life overrides. Override this variable in the local 'justfile'.
+# Define mappings from LTS minor versions to their EOL date in YYYY-MM-DD format.
+# Example: lts_releases := '{"2.14": "2026-12-31", "2.12": "2025-06-30"}'
+lts_releases := '{}'
+
+[private]
+@default:
+  just --list
+  echo "{{rock_name}}"
+  echo "For help with a specific recipe, run: just --usage <recipe>"
+
+# Push an OCI image to a local registry
+[private]
+@push-to-registry version=latest_version:
+  which -s docker || { echo "docker not found"; exit 1; }
+  test -f "{{version}}/{{rock_name}}_{{version}}_amd64.rock" || rockcraft pack
+  echo "Pushing {{version}} to local docker registry"
+  cd {{version}}; sudo rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false "oci-archive:{{rock_name}}_{{version}}_amd64.rock" docker-daemon:rockcraft-test:latest
+  echo "✓ Rock pushed to local registry under 'rockcraft-test:latest'"
+
+# Print the rock name
+[group("info")]
+@name:
+  echo "{{rock_name}}"
+
+# Print the latest rock version
+[group("info")]
+@latest-version:
+  echo "{{latest_version}}"
+
+# Pack a rock of a specific component and version
+[group("dev")]
+pack version=latest_version:
+  cd "{{version}}" && rockcraft pack
+
+# `rockcraft clean` for a specific component and version
+[group("dev")]
+clean version=latest_version:
+  cd "{{version}}" && rockcraft clean
+
+# Run a rock and open a shell into it with `docker`
+[group("dev")]
+run version=latest_version: (push-to-registry version)
+  which -s dgoss || { echo "dgoss not found"; exit 1; }
+  dgoss edit rockcraft-test:latest || true
+
+# Test a rock with `rockcraft test`
+[group("dev")]
+test version=latest_version:
+  #!/usr/bin/env bash
+  set -e
+  cp spread.yaml "{{version}}/spread.yaml"
+  if [ -f goss.yaml ]; then cp goss.yaml "{{version}}/goss.yaml"; fi
+  test_exit=0; (cd "{{version}}" && rockcraft test) || test_exit=$?
+  rm -f "{{version}}/spread.yaml" "{{version}}/goss.yaml"
+  if [ "$test_exit" -ne 0 ]; then echo "× rockcraft test failed"; exit "$test_exit"; fi
+  echo "✓ 'rockcraft test' passed."
+
+# Generate SBOM for the rock
+[group("security")]
+sbom version=latest_version:
+  syft {{version}}/*.rock -o "spdx-json={{version}}/rock.sbom.json"
+  @echo "✓ SBOM saved to {{version}}/rock.sbom.json"
+
+# Perform a securiy scan
+[group("security")]
+scan version=latest_version: (sbom version)
+  uvx --from=trivy-py trivy sbom "{{version}}/rock.sbom.json"
+  @echo "✓ Vulnerability scan done"
+
+# Check whether CVEs affect the upstream project
+[group("security")]
+govulncheck source_repo version=latest_version:
+  #!/usr/bin/env bash
+  set -e
+  echo "Cloning {{source_repo}}"
+  which -s govulncheck || { echo "govulncheck not found; install it with:  go install golang.org/x/vuln/cmd/govulncheck@latest"; exit 1; }
+  TMP_DIR="$(mktemp -d)"
+  gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "{{version}}" --depth 1 2>/dev/null \
+    || gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "v{{version}}" --depth 1
+  if [[ ! -f "$TMP_DIR/{{source_repo}}/go.mod" ]]; then
+    echo "⨯ {{source_repo}} is not a Go project (go.mod is missing)"
+    exit 2
+  fi
+  echo "Running 'govulncheck' (this may take a while)"
+  vuln_exit=0; (cd "$TMP_DIR/{{source_repo}}" && govulncheck ./...) || vuln_exit=$?
+  rm -rf "$TMP_DIR"
+  if [ "$vuln_exit" -ne 0 ]; then echo "⨯ 'govulncheck' failed"; exit "$vuln_exit"; fi
+  echo "✓ 'govulncheck' passed."
+
+# Generate a rock for the latest version of the upstream project
+[arg("source_repo", help="Repository of the upstream project in 'org/repo' form")]
+[group("maintenance")]
+update source_repo release_tag="":
+  #!/usr/bin/env bash
+  set -e
+  if [[ -z "{{release_tag}}" ]]; then
+    latest_release="$(gh release list --repo {{source_repo}} --exclude-pre-releases --limit=1 --json tagName --jq '.[0].tagName')"
+    echo "Latest release for {{source_repo}} is $latest_release"
+  else
+    latest_release="{{release_tag}}"
+    echo "Release version manually set to $latest_release"
+  fi
+  # Explicitly filter out prefixes for known rocks, so we can notice if a new rock has a different schema
+  version="${latest_release}"
+  version="${version#mimir-}"  # mimir
+  version="${version#cmd/builder/v}"  # opentelemetry-collector
+  version="${version#v}"  # Generic v- prefix
+  # If the version already exists as a rock, exit here
+  if [[ -d "$version" ]]; then echo "Folder $version already exists, nothing to do" && exit 0; fi
+  # Create the folder for the new version and update the rockcraft.yaml
+  cp -r "{{latest_version}}" "$version"
+  latest_release="$latest_release" version="$version" yq -i \
+    '.version = strenv(version) | .parts.{{rock_name}}["source-tag"] = strenv(latest_release)' \
+    "./$version/rockcraft.yaml"
+  # Automatically update build tools (go) from the upstream repository
+  TMP_DIR="$(mktemp -d)"
+  gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "$latest_release" --depth 1
+  # If it's a Go project, update the Go version
+  if [[ -f "$TMP_DIR/{{source_repo}}/go.mod" ]]; then
+    go_snap_version="$(grep -Po '^go \K(\S+)' "$TMP_DIR/{{source_repo}}/go.mod" | sed -E 's/([0-9]+\.[0-9]+).*/\1/')"
+    go_snap_version="$go_snap_version" yq -i \
+      '(.parts.{{rock_name}}.build-snaps[] | select(test("^go/"))) = "go/"+strenv(go_snap_version)+"/candidate"' \
+      "./$version/rockcraft.yaml"
+  fi
+  rm -rf "$TMP_DIR"
+  echo "✓ Created rock for version $version"
+
+# Fetch centralized files from canonical/observability
+[group("maintenance")]
+refresh:
+  #!/usr/bin/env bash
+  which -s gh || { echo "gh not found"; exit 1; }
+  refresh_folder="blueprints/rocks"
+  api_path="repos/canonical/observability/contents/$refresh_folder"
+  for file in rocks.just spread.yaml; do
+    echo "Fetching latest '$file' from canonical/observability ..."
+    gh api "$api_path/$file" --jq '.content' | base64 --decode > "$file"
+    echo "✓ $file updated"
+  done
+
+# Release rock to GHCR with tag `:dev`
+[group("release")]
+release-ghcr version=latest_version github_user="observability-noctua-bot":
+  #!/usr/bin/env bash
+  set -e
+  if [[ -z "$GITHUB_TOKEN" ]]; then echo "× Please export GITHUB_TOKEN for the user {{github_user}}"; exit 1; fi
+  if [ ! -e {{version}}/*.rock ]; then echo "× Error: rock not found. Please run 'just pack {{version}}' first."; exit 2; fi
+  sudo rockcraft.skopeo --insecure-policy copy \
+    "oci-archive:$(realpath ./{{version}}/*.rock)" \
+    "docker://ghcr.io/canonical/{{rock_name}}:dev" \
+    --dest-creds "{{github_user}}:${GITHUB_TOKEN}"
+  echo "✓ {{rock_name}} {{version}} pushed to GHCR with tag ':dev'"
+
+# Open a PR to OCI Factory
+[group("release")]
+[arg("support",pattern="major|minor|patch")]
+[arg("risk", pattern="stable|candidate|beta|edge")]
+release-oci-factory version=latest_version support="minor" risk="stable":
+  #!/usr/bin/env bash
+  set -e
+  if [[ -z "$GITHUB_TOKEN" ]]; then echo "× Please export GITHUB_TOKEN for the user observability-noctua-bot"; exit 1; fi
+  if [ ! -e {{version}}/*.rock ]; then echo "× Error: rock not found. Please run 'just pack {{version}}' first."; exit 2; fi
+  repository="$(git remote get-url origin | sed -E 's#(git@[^:]+:|https?://[^/]+/)##; s/\.git$//')"
+  # Extract the base from the rockcraft.yaml (e.g. "ubuntu@24.04" -> "24.04")
+  rock_base="$(yq -r '.base' "{{version}}/rockcraft.yaml" | sed 's/.*@//')"
+  echo "Detected base: $rock_base"
+  # Clone the oci-factory and push data to it
+  gh repo sync --force observability-noctua-bot/oci-factory
+  TMP_DIR="$(mktemp -d)"
+  git clone https://github.com/observability-noctua-bot/oci-factory "$TMP_DIR/oci-factory"
+  echo "✓ Cloned observability-noctua-bot/oci-factory"
+  # Build the OCI Factory manifest
+  # Check if this version has a custom EOL in lts_releases
+  minor_version="$(echo "{{version}}" | grep -oP '^\d+\.\d+')"
+  eol_date="$(echo '{{lts_releases}}' | jq -r --arg v "$minor_version" '.[$v] // empty')"
+  eol_flag=""
+  if [[ -n "$eol_date" ]]; then
+    eol_flag="--eol=$eol_date"
+    echo "LTS release detected: EOL set to $eol_date"
+  fi
+  echo "Building the OCI Factory manifest..."; echo
+  manifest_file="$TMP_DIR/oci-factory/oci/{{rock_name}}/image.yaml"
+  uvx --from=git+https://github.com/lucabello/noctua noctua rock manifest \
+    "$repository" \
+    --commit="$(git rev-parse HEAD)" \
+    --base="$rock_base" \
+    --support="{{support}}" \
+    --risk="{{risk}}" \
+    --version="{{version}}" \
+    $eol_flag \
+    | tee "$manifest_file"
+  echo; echo "✓ OCI Factory manifest generated"
+  # If there's nothing to upload, exit early
+  upload_count="$(cat "$manifest_file" | yq '.upload | length')"
+  if [[ "$upload_count" -eq 0 ]]; then
+    echo "✓ Nothing to update in OCI Factory"
+    rm -rf "$TMP_DIR"
+    exit 0
+  fi
+  # Commit the changes and create a PR
+  pushd "$TMP_DIR/oci-factory" >/dev/null
+  git config user.name observability-noctua-bot
+  git config user.email webops+observability-noctua-bot@canonical.com
+  git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/observability-noctua-bot/oci-factory.git"
+  branch_name="update-$(date -d now +%s)"
+  git checkout -b "$branch_name"
+  git add oci/{{rock_name}}/image.yaml
+  git commit -m "chore: Add new {{rock_name}} releases"
+  git push -u origin "$branch_name" --force
+  echo "✓ Changes have been pushed to ${branch_name}"
+  gh pr create --repo canonical/oci-factory \
+    --head "observability-noctua-bot:${branch_name}" \
+    --title "chore: Add new {{rock_name}} releases" \
+    --body "This is an automatic PR opened by the Observability Noctua bot."
+  popd >/dev/null
+  rm -rf "$TMP_DIR"
+  echo "✓ Release to OCI Factory completed"

--- a/rocks/istio-pilot-rock/spread.yaml
+++ b/rocks/istio-pilot-rock/spread.yaml
@@ -1,0 +1,41 @@
+project: rock
+
+backends:
+  craft:
+    type: craft
+    systems:
+      - ubuntu-24.04:
+      #- ubuntu-22.04:
+
+suites:
+  spread/general/:
+    summary: General integration tests
+    environment:
+      # Goss environment
+      GOSS_OPTS: "--retry-timeout=60s"
+      GOSS_FILES_STRATEGY: cp
+      DGOSS_TEMP_DIR: "$HOME"
+
+    prepare: |
+      # Install dependencies
+      sudo snap install docker
+      curl -fsSL https://goss.rocks/install | sh
+
+      # For 'rockcraft.skopeo'
+      sudo snap install --classic rockcraft
+
+      # Wait for docker daemon to come online
+      sudo apt install --yes retry
+      retry --times=10 --delay 2 -- docker run hello-world
+      sudo apt remove --yes retry
+
+      # Load the rock into docker
+      sudo rockcraft.skopeo --insecure-policy copy "oci-archive:$CRAFT_ARTIFACT" docker-daemon:rockcraft-test:latest
+      
+    restore: |
+      docker image rm --force rockcraft-test:latest
+
+exclude:
+  - .git
+
+kill-timeout: 1h

--- a/rocks/istio-ztunnel-rock/.gitignore
+++ b/rocks/istio-ztunnel-rock/.gitignore
@@ -1,0 +1,14 @@
+# Ignore all spread.yaml files
+*/*/spread.yaml
+
+# Except the one in the top-level directory
+!/spread.yaml
+
+# Ignore copied goss.yaml files in component version directories
+*/*/goss.yaml
+
+# Ignore rocks
+*.rock
+
+# Ignore sboms
+*.sbom.json

--- a/rocks/istio-ztunnel-rock/1.29.0/rockcraft.yaml
+++ b/rocks/istio-ztunnel-rock/1.29.0/rockcraft.yaml
@@ -1,0 +1,48 @@
+name: istio-ztunnel
+base: ubuntu@24.04
+version: '1.29.0'
+summary: Ztunnel provides an implementation of the ztunnel component of ambient mesh
+description: |
+  Ztunnel is intended to be a purpose built implementation of the node proxy in ambient mesh. Part of the goals of this included keeping a narrow feature set, implementing only the bare minimum requirements for ambient. This ensures the project remains simple and high performance.
+platforms:
+  amd64:
+
+services:
+  ztunnel:
+    command: /bin/ztunnel proxy
+    override: replace
+    startup: enabled
+
+parts:
+  istio-ztunnel:
+    plugin: rust
+    source: https://github.com/istio/ztunnel.git
+    source-tag: 1.29.0
+    rust-channel: 1.92.0
+    build-packages:
+      - protobuf-compiler
+  # install packages provided by the istio/iptables distroless image, which is a base for ztunnel
+  # as seen [here](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.ztunnel).
+  # The base image is defined [here](https://github.com/istio/istio/blob/master/docker/iptables.yaml) using apko,
+  # which is a tool for making distroless-like images.  apko's package names do not directly map to those in apt,
+  # so a bit of inference is applied to the list below.
+  stage-dependency-packages:
+    plugin: nil
+    stage-packages:
+      - libc6  # glibc
+      - iptables  # includes both iptables and ip6tables
+      - conntrack  # libnetfilter_conntrack and libnfnetlink (and maybe libmnl?)
+      - gcc
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - istio-ztunnel
+      - stage-dependency-packages
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/rocks/istio-ztunnel-rock/1.29.0/spread/.extension
+++ b/rocks/istio-ztunnel-rock/1.29.0/spread/.extension
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+usage() {
+    echo "usage: $(basename "$0") [command]"
+    echo "valid commands:"
+    echo "    allocate              Create a backend instance to run tests on"
+    echo "    discard               Destroy a backend instance used to run tests"
+    echo "    backend-prepare       Set up the system to run tests"
+    echo "    backend-restore       Restore the system after the tests ran"
+    echo "    backend-prepare-each  Prepare the system before each test"
+    echo "    backend-restore-each  Restore the system after each test run"
+}
+
+prepare() {
+    case "$SPREAD_SYSTEM" in
+    fedora*)
+        dnf update -y
+        dnf install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    debian*)
+        apt update
+        apt install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    ubuntu*)
+        apt update
+        ;;
+    esac
+
+    snap wait system seed.loaded
+    snap refresh --hold
+
+    if systemctl is-enabled unattended-upgrades.service; then
+        systemctl stop unattended-upgrades.service
+        systemctl mask unattended-upgrades.service
+    fi
+}
+
+restore() {
+    case "$SPREAD_SYSTEM" in
+    ubuntu* | debian*)
+        apt autoremove -y --purge
+        ;;
+    esac
+
+    rm -Rf "$PROJECT_PATH"
+    mkdir -p "$PROJECT_PATH"
+}
+
+prepare_each() {
+    true
+}
+
+restore_each() {
+    true
+}
+
+allocate_lxdvm() {
+    name=$(echo "$SPREAD_SYSTEM" | tr '[:punct:]' -)
+    system=$(echo "$SPREAD_SYSTEM" | tr / -)
+    if [[ "$system" =~ ^ubuntu- ]]; then
+        image="ubuntu:${system#ubuntu-}"
+    else
+        image="images:$(echo "$system" | tr - /)"
+    fi
+
+    VM_NAME="${VM_NAME:-spread-${name}-${RANDOM}}"
+    DISK="${DISK:-20}"
+    CPU="${CPU:-4}"
+    MEM="${MEM:-8}"
+
+    lxc launch --vm \
+        "${image}" \
+        "${VM_NAME}" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+    while ! lxc exec "${VM_NAME}" -- true &>/dev/null; do sleep 0.5; done
+    lxc exec "${VM_NAME}" -- sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    lxc exec "${VM_NAME}" -- bash -c "if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' > /etc/ssh/sshd_config.d/00-spread.conf; fi"
+    lxc exec "${VM_NAME}" -- bash -c "echo root:${SPREAD_PASSWORD} | sudo chpasswd || true"
+
+    # Print the instance address to stdout
+    ADDR=""
+    while [ -z "$ADDR" ]; do ADDR=$(lxc ls -f csv | grep "^${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1); done
+    echo "$ADDR" 1>&3
+}
+
+discard_lxdvm() {
+    instance_name="$(lxc ls -f csv | sed ':a;N;$!ba;s/(docker0)\n/(docker0) /' | grep "$SPREAD_SYSTEM_ADDRESS " | cut -f1 -d",")"
+    lxc delete -f "$instance_name"
+}
+
+allocate_ci() {
+    if [ -z "$CI" ]; then
+        echo "This backend is intended to be used only in CI systems."
+        exit 1
+    fi
+    sudo sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/00-spread.conf; fi
+    sudo systemctl daemon-reload
+    sudo systemctl restart ssh
+
+    echo "root:${SPREAD_PASSWORD}" | sudo chpasswd || true
+
+    # Print the instance address to stdout
+    echo localhost >&3
+}
+
+discard_ci() {
+    true
+}
+
+allocate() {
+    exec 3>&1
+    exec 1>&2
+
+    case "$1" in
+    lxd-vm)
+        allocate_lxdvm
+        ;;
+    ci)
+        allocate_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+discard() {
+    case "$1" in
+    lxd-vm)
+        discard_lxdvm
+        ;;
+    ci)
+        discard_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+set -e
+
+while getopts "" o; do
+    case "${o}" in
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+CMD="$1"
+PARM="$2"
+
+if [ -z "$CMD" ]; then
+    usage
+    exit 0
+fi
+
+case "$CMD" in
+allocate)
+    allocate "$PARM"
+    ;;
+discard)
+    discard "$PARM"
+    ;;
+backend-prepare)
+    prepare
+    ;;
+backend-restore)
+    restore
+    ;;
+backend-prepare-each)
+    prepare_each
+    ;;
+backend-restore-each)
+    restore_each
+    ;;
+*)
+    echo "unknown command $CMD" >&2
+    ;;
+esac

--- a/rocks/istio-ztunnel-rock/1.29.0/spread/general/ready/task.yaml
+++ b/rocks/istio-ztunnel-rock/1.29.0/spread/general/ready/task.yaml
@@ -1,0 +1,7 @@
+summary: Run goss tests
+
+environment:
+  GOSS_FILE: "../../../goss.yaml"
+
+execute: |
+  dgoss run rockcraft-test:latest

--- a/rocks/istio-ztunnel-rock/1.30.0/rockcraft.yaml
+++ b/rocks/istio-ztunnel-rock/1.30.0/rockcraft.yaml
@@ -1,0 +1,48 @@
+name: istio-ztunnel
+base: ubuntu@26.04
+version: '1.30.0'
+summary: Ztunnel provides an implementation of the ztunnel component of ambient mesh
+description: |
+  Ztunnel is intended to be a purpose built implementation of the node proxy in ambient mesh. Part of the goals of this included keeping a narrow feature set, implementing only the bare minimum requirements for ambient. This ensures the project remains simple and high performance.
+platforms:
+  amd64:
+
+services:
+  ztunnel:
+    command: /bin/ztunnel proxy
+    override: replace
+    startup: enabled
+
+parts:
+  istio-ztunnel:
+    plugin: rust
+    source: https://github.com/istio/ztunnel.git
+    source-tag: 1.30.0
+    rust-channel: 1.92.0
+    build-packages:
+      - protobuf-compiler
+  # install packages provided by the istio/iptables distroless image, which is a base for ztunnel
+  # as seen [here](https://github.com/istio/istio/blob/master/pilot/docker/Dockerfile.ztunnel).
+  # The base image is defined [here](https://github.com/istio/istio/blob/master/docker/iptables.yaml) using apko,
+  # which is a tool for making distroless-like images.  apko's package names do not directly map to those in apt,
+  # so a bit of inference is applied to the list below.
+  stage-dependency-packages:
+    plugin: nil
+    stage-packages:
+      - libc6  # glibc
+      - iptables  # includes both iptables and ip6tables
+      - conntrack  # libnetfilter_conntrack and libnfnetlink (and maybe libmnl?)
+      - gcc
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - istio-ztunnel
+      - stage-dependency-packages
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/rocks/istio-ztunnel-rock/1.30.0/spread/.extension
+++ b/rocks/istio-ztunnel-rock/1.30.0/spread/.extension
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+usage() {
+    echo "usage: $(basename "$0") [command]"
+    echo "valid commands:"
+    echo "    allocate              Create a backend instance to run tests on"
+    echo "    discard               Destroy a backend instance used to run tests"
+    echo "    backend-prepare       Set up the system to run tests"
+    echo "    backend-restore       Restore the system after the tests ran"
+    echo "    backend-prepare-each  Prepare the system before each test"
+    echo "    backend-restore-each  Restore the system after each test run"
+}
+
+prepare() {
+    case "$SPREAD_SYSTEM" in
+    fedora*)
+        dnf update -y
+        dnf install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    debian*)
+        apt update
+        apt install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    ubuntu*)
+        apt update
+        ;;
+    esac
+
+    snap wait system seed.loaded
+    snap refresh --hold
+
+    if systemctl is-enabled unattended-upgrades.service; then
+        systemctl stop unattended-upgrades.service
+        systemctl mask unattended-upgrades.service
+    fi
+}
+
+restore() {
+    case "$SPREAD_SYSTEM" in
+    ubuntu* | debian*)
+        apt autoremove -y --purge
+        ;;
+    esac
+
+    rm -Rf "$PROJECT_PATH"
+    mkdir -p "$PROJECT_PATH"
+}
+
+prepare_each() {
+    true
+}
+
+restore_each() {
+    true
+}
+
+allocate_lxdvm() {
+    name=$(echo "$SPREAD_SYSTEM" | tr '[:punct:]' -)
+    system=$(echo "$SPREAD_SYSTEM" | tr / -)
+    if [[ "$system" =~ ^ubuntu- ]]; then
+        image="ubuntu:${system#ubuntu-}"
+    else
+        image="images:$(echo "$system" | tr - /)"
+    fi
+
+    VM_NAME="${VM_NAME:-spread-${name}-${RANDOM}}"
+    DISK="${DISK:-20}"
+    CPU="${CPU:-4}"
+    MEM="${MEM:-8}"
+
+    lxc launch --vm \
+        "${image}" \
+        "${VM_NAME}" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+    while ! lxc exec "${VM_NAME}" -- true &>/dev/null; do sleep 0.5; done
+    lxc exec "${VM_NAME}" -- sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    lxc exec "${VM_NAME}" -- bash -c "if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' > /etc/ssh/sshd_config.d/00-spread.conf; fi"
+    lxc exec "${VM_NAME}" -- bash -c "echo root:${SPREAD_PASSWORD} | sudo chpasswd || true"
+
+    # Print the instance address to stdout
+    ADDR=""
+    while [ -z "$ADDR" ]; do ADDR=$(lxc ls -f csv | grep "^${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1); done
+    echo "$ADDR" 1>&3
+}
+
+discard_lxdvm() {
+    instance_name="$(lxc ls -f csv | sed ':a;N;$!ba;s/(docker0)\n/(docker0) /' | grep "$SPREAD_SYSTEM_ADDRESS " | cut -f1 -d",")"
+    lxc delete -f "$instance_name"
+}
+
+allocate_ci() {
+    if [ -z "$CI" ]; then
+        echo "This backend is intended to be used only in CI systems."
+        exit 1
+    fi
+    sudo sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/00-spread.conf; fi
+    sudo systemctl daemon-reload
+    sudo systemctl restart ssh
+
+    echo "root:${SPREAD_PASSWORD}" | sudo chpasswd || true
+
+    # Print the instance address to stdout
+    echo localhost >&3
+}
+
+discard_ci() {
+    true
+}
+
+allocate() {
+    exec 3>&1
+    exec 1>&2
+
+    case "$1" in
+    lxd-vm)
+        allocate_lxdvm
+        ;;
+    ci)
+        allocate_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+discard() {
+    case "$1" in
+    lxd-vm)
+        discard_lxdvm
+        ;;
+    ci)
+        discard_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+set -e
+
+while getopts "" o; do
+    case "${o}" in
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+CMD="$1"
+PARM="$2"
+
+if [ -z "$CMD" ]; then
+    usage
+    exit 0
+fi
+
+case "$CMD" in
+allocate)
+    allocate "$PARM"
+    ;;
+discard)
+    discard "$PARM"
+    ;;
+backend-prepare)
+    prepare
+    ;;
+backend-restore)
+    restore
+    ;;
+backend-prepare-each)
+    prepare_each
+    ;;
+backend-restore-each)
+    restore_each
+    ;;
+*)
+    echo "unknown command $CMD" >&2
+    ;;
+esac

--- a/rocks/istio-ztunnel-rock/1.30.0/spread/general/ready/task.yaml
+++ b/rocks/istio-ztunnel-rock/1.30.0/spread/general/ready/task.yaml
@@ -1,0 +1,7 @@
+summary: Run goss tests
+
+environment:
+  GOSS_FILE: "../../../goss.yaml"
+
+execute: |
+  dgoss run rockcraft-test:latest

--- a/rocks/istio-ztunnel-rock/CODEOWNERS
+++ b/rocks/istio-ztunnel-rock/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/service-mesh

--- a/rocks/istio-ztunnel-rock/LICENSE
+++ b/rocks/istio-ztunnel-rock/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/rocks/istio-ztunnel-rock/README.md
+++ b/rocks/istio-ztunnel-rock/README.md
@@ -1,0 +1,15 @@
+# ztunnel-rock
+
+[![Open a PR to OCI Factory](https://github.com/canonical/ztunnel-rock/actions/workflows/release-oci-factory.yaml/badge.svg)](https://github.com/canonical/ztunnel-rock/actions/workflows/release-oci-factory.yaml)
+[![Publish to GHCR:dev](https://github.com/canonical/ztunnel-rock/actions/workflows/release-dev.yaml/badge.svg)](https://github.com/canonical/ztunnel-rock/actions/workflows/release-dev.yaml)
+[![Update rock](https://github.com/canonical/ztunnel-rock/actions/workflows/update.yaml/badge.svg)](https://github.com/canonical/ztunnel-rock/actions/workflows/update.yaml)
+
+A [rock](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/) for [Istio's](https://istio.io/) [ztunnel](https://hub.docker.com/r/istio/ztunnel) image.  
+This repository holds all the necessary files to build a rock for the upstream versions we support. The rock is used indirectly by the [istio-k8s-operator](https://github.com/canonical/istio-k8s-operator/) charm.
+
+The rocks on this repository are built with [OCI Factory](https://github.com/canonical/oci-factory/), which also takes care of periodically rebuilding the images.
+
+Automation takes care of:
+* validating PRs, by simply trying to build the rock;
+* pulling upstream releases, creating a PR with the necessary files to be manually reviewed;
+* releasing to GHCR at [ghcr.io/canonical/istio-install-cni:dev](https://ghcr.io/canonical/istio-install-cni:dev), when merging to main, for development purposes.

--- a/rocks/istio-ztunnel-rock/goss.yaml
+++ b/rocks/istio-ztunnel-rock/goss.yaml
@@ -1,0 +1,4 @@
+# TODO: write some actual goss tests
+command:
+  true:
+    exit-status: 0

--- a/rocks/istio-ztunnel-rock/justfile
+++ b/rocks/istio-ztunnel-rock/justfile
@@ -1,0 +1,9 @@
+set allow-duplicate-recipes
+set allow-duplicate-variables
+import? 'rocks.just'
+
+[private]
+@default:
+  just --list
+  echo ""
+  echo "For help with a specific recipe, run: just --usage <recipe>"

--- a/rocks/istio-ztunnel-rock/rocks.just
+++ b/rocks/istio-ztunnel-rock/rocks.just
@@ -1,0 +1,224 @@
+# Centralized justfile for the Canonical Observability rocks
+set shell := ["bash", "-uc"]
+
+rock_name := `echo ${PWD##*/} | sed 's/-rock$//'`  # Get the rock name from the folder name
+latest_version := `find . -name rockcraft.yaml -printf '%h\n' | sort -V | tail -n1 | sed 's@./@@'`
+
+# LTS end-of-life overrides. Override this variable in the local 'justfile'.
+# Define mappings from LTS minor versions to their EOL date in YYYY-MM-DD format.
+# Example: lts_releases := '{"2.14": "2026-12-31", "2.12": "2025-06-30"}'
+lts_releases := '{}'
+
+[private]
+@default:
+  just --list
+  echo "{{rock_name}}"
+  echo "For help with a specific recipe, run: just --usage <recipe>"
+
+# Push an OCI image to a local registry
+[private]
+@push-to-registry version=latest_version:
+  which -s docker || { echo "docker not found"; exit 1; }
+  test -f "{{version}}/{{rock_name}}_{{version}}_amd64.rock" || rockcraft pack
+  echo "Pushing {{version}} to local docker registry"
+  cd {{version}}; sudo rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false "oci-archive:{{rock_name}}_{{version}}_amd64.rock" docker-daemon:rockcraft-test:latest
+  echo "✓ Rock pushed to local registry under 'rockcraft-test:latest'"
+
+# Print the rock name
+[group("info")]
+@name:
+  echo "{{rock_name}}"
+
+# Print the latest rock version
+[group("info")]
+@latest-version:
+  echo "{{latest_version}}"
+
+# Pack a rock of a specific component and version
+[group("dev")]
+pack version=latest_version:
+  cd "{{version}}" && rockcraft pack
+
+# `rockcraft clean` for a specific component and version
+[group("dev")]
+clean version=latest_version:
+  cd "{{version}}" && rockcraft clean
+
+# Run a rock and open a shell into it with `docker`
+[group("dev")]
+run version=latest_version: (push-to-registry version)
+  which -s dgoss || { echo "dgoss not found"; exit 1; }
+  dgoss edit rockcraft-test:latest || true
+
+# Test a rock with `rockcraft test`
+[group("dev")]
+test version=latest_version:
+  #!/usr/bin/env bash
+  set -e
+  cp spread.yaml "{{version}}/spread.yaml"
+  if [ -f goss.yaml ]; then cp goss.yaml "{{version}}/goss.yaml"; fi
+  test_exit=0; (cd "{{version}}" && rockcraft test) || test_exit=$?
+  rm -f "{{version}}/spread.yaml" "{{version}}/goss.yaml"
+  if [ "$test_exit" -ne 0 ]; then echo "× rockcraft test failed"; exit "$test_exit"; fi
+  echo "✓ 'rockcraft test' passed."
+
+# Generate SBOM for the rock
+[group("security")]
+sbom version=latest_version:
+  syft {{version}}/*.rock -o "spdx-json={{version}}/rock.sbom.json"
+  @echo "✓ SBOM saved to {{version}}/rock.sbom.json"
+
+# Perform a securiy scan
+[group("security")]
+scan version=latest_version: (sbom version)
+  uvx --from=trivy-py trivy sbom "{{version}}/rock.sbom.json"
+  @echo "✓ Vulnerability scan done"
+
+# Check whether CVEs affect the upstream project
+[group("security")]
+govulncheck source_repo version=latest_version:
+  #!/usr/bin/env bash
+  set -e
+  echo "Cloning {{source_repo}}"
+  which -s govulncheck || { echo "govulncheck not found; install it with:  go install golang.org/x/vuln/cmd/govulncheck@latest"; exit 1; }
+  TMP_DIR="$(mktemp -d)"
+  gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "{{version}}" --depth 1 2>/dev/null \
+    || gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "v{{version}}" --depth 1
+  if [[ ! -f "$TMP_DIR/{{source_repo}}/go.mod" ]]; then
+    echo "⨯ {{source_repo}} is not a Go project (go.mod is missing)"
+    exit 2
+  fi
+  echo "Running 'govulncheck' (this may take a while)"
+  vuln_exit=0; (cd "$TMP_DIR/{{source_repo}}" && govulncheck ./...) || vuln_exit=$?
+  rm -rf "$TMP_DIR"
+  if [ "$vuln_exit" -ne 0 ]; then echo "⨯ 'govulncheck' failed"; exit "$vuln_exit"; fi
+  echo "✓ 'govulncheck' passed."
+
+# Generate a rock for the latest version of the upstream project
+[arg("source_repo", help="Repository of the upstream project in 'org/repo' form")]
+[group("maintenance")]
+update source_repo release_tag="":
+  #!/usr/bin/env bash
+  set -e
+  if [[ -z "{{release_tag}}" ]]; then
+    latest_release="$(gh release list --repo {{source_repo}} --exclude-pre-releases --limit=1 --json tagName --jq '.[0].tagName')"
+    echo "Latest release for {{source_repo}} is $latest_release"
+  else
+    latest_release="{{release_tag}}"
+    echo "Release version manually set to $latest_release"
+  fi
+  # Explicitly filter out prefixes for known rocks, so we can notice if a new rock has a different schema
+  version="${latest_release}"
+  version="${version#mimir-}"  # mimir
+  version="${version#cmd/builder/v}"  # opentelemetry-collector
+  version="${version#v}"  # Generic v- prefix
+  # If the version already exists as a rock, exit here
+  if [[ -d "$version" ]]; then echo "Folder $version already exists, nothing to do" && exit 0; fi
+  # Create the folder for the new version and update the rockcraft.yaml
+  cp -r "{{latest_version}}" "$version"
+  latest_release="$latest_release" version="$version" yq -i \
+    '.version = strenv(version) | .parts.{{rock_name}}["source-tag"] = strenv(latest_release)' \
+    "./$version/rockcraft.yaml"
+  # Automatically update build tools (go) from the upstream repository
+  TMP_DIR="$(mktemp -d)"
+  gh repo clone "{{source_repo}}" "$TMP_DIR/{{source_repo}}" -- --branch "$latest_release" --depth 1
+  # If it's a Go project, update the Go version
+  if [[ -f "$TMP_DIR/{{source_repo}}/go.mod" ]]; then
+    go_snap_version="$(grep -Po '^go \K(\S+)' "$TMP_DIR/{{source_repo}}/go.mod" | sed -E 's/([0-9]+\.[0-9]+).*/\1/')"
+    go_snap_version="$go_snap_version" yq -i \
+      '(.parts.{{rock_name}}.build-snaps[] | select(test("^go/"))) = "go/"+strenv(go_snap_version)+"/candidate"' \
+      "./$version/rockcraft.yaml"
+  fi
+  rm -rf "$TMP_DIR"
+  echo "✓ Created rock for version $version"
+
+# Fetch centralized files from canonical/observability
+[group("maintenance")]
+refresh:
+  #!/usr/bin/env bash
+  which -s gh || { echo "gh not found"; exit 1; }
+  refresh_folder="blueprints/rocks"
+  api_path="repos/canonical/observability/contents/$refresh_folder"
+  for file in rocks.just spread.yaml; do
+    echo "Fetching latest '$file' from canonical/observability ..."
+    gh api "$api_path/$file" --jq '.content' | base64 --decode > "$file"
+    echo "✓ $file updated"
+  done
+
+# Release rock to GHCR with tag `:dev`
+[group("release")]
+release-ghcr version=latest_version github_user="observability-noctua-bot":
+  #!/usr/bin/env bash
+  set -e
+  if [[ -z "$GITHUB_TOKEN" ]]; then echo "× Please export GITHUB_TOKEN for the user {{github_user}}"; exit 1; fi
+  if [ ! -e {{version}}/*.rock ]; then echo "× Error: rock not found. Please run 'just pack {{version}}' first."; exit 2; fi
+  sudo rockcraft.skopeo --insecure-policy copy \
+    "oci-archive:$(realpath ./{{version}}/*.rock)" \
+    "docker://ghcr.io/canonical/{{rock_name}}:dev" \
+    --dest-creds "{{github_user}}:${GITHUB_TOKEN}"
+  echo "✓ {{rock_name}} {{version}} pushed to GHCR with tag ':dev'"
+
+# Open a PR to OCI Factory
+[group("release")]
+[arg("support",pattern="major|minor|patch")]
+[arg("risk", pattern="stable|candidate|beta|edge")]
+release-oci-factory version=latest_version support="minor" risk="stable":
+  #!/usr/bin/env bash
+  set -e
+  if [[ -z "$GITHUB_TOKEN" ]]; then echo "× Please export GITHUB_TOKEN for the user observability-noctua-bot"; exit 1; fi
+  if [ ! -e {{version}}/*.rock ]; then echo "× Error: rock not found. Please run 'just pack {{version}}' first."; exit 2; fi
+  repository="$(git remote get-url origin | sed -E 's#(git@[^:]+:|https?://[^/]+/)##; s/\.git$//')"
+  # Extract the base from the rockcraft.yaml (e.g. "ubuntu@24.04" -> "24.04")
+  rock_base="$(yq -r '.base' "{{version}}/rockcraft.yaml" | sed 's/.*@//')"
+  echo "Detected base: $rock_base"
+  # Clone the oci-factory and push data to it
+  gh repo sync --force observability-noctua-bot/oci-factory
+  TMP_DIR="$(mktemp -d)"
+  git clone https://github.com/observability-noctua-bot/oci-factory "$TMP_DIR/oci-factory"
+  echo "✓ Cloned observability-noctua-bot/oci-factory"
+  # Build the OCI Factory manifest
+  # Check if this version has a custom EOL in lts_releases
+  minor_version="$(echo "{{version}}" | grep -oP '^\d+\.\d+')"
+  eol_date="$(echo '{{lts_releases}}' | jq -r --arg v "$minor_version" '.[$v] // empty')"
+  eol_flag=""
+  if [[ -n "$eol_date" ]]; then
+    eol_flag="--eol=$eol_date"
+    echo "LTS release detected: EOL set to $eol_date"
+  fi
+  echo "Building the OCI Factory manifest..."; echo
+  manifest_file="$TMP_DIR/oci-factory/oci/{{rock_name}}/image.yaml"
+  uvx --from=git+https://github.com/lucabello/noctua noctua rock manifest \
+    "$repository" \
+    --commit="$(git rev-parse HEAD)" \
+    --base="$rock_base" \
+    --support="{{support}}" \
+    --risk="{{risk}}" \
+    --version="{{version}}" \
+    $eol_flag \
+    | tee "$manifest_file"
+  echo; echo "✓ OCI Factory manifest generated"
+  # If there's nothing to upload, exit early
+  upload_count="$(cat "$manifest_file" | yq '.upload | length')"
+  if [[ "$upload_count" -eq 0 ]]; then
+    echo "✓ Nothing to update in OCI Factory"
+    rm -rf "$TMP_DIR"
+    exit 0
+  fi
+  # Commit the changes and create a PR
+  pushd "$TMP_DIR/oci-factory" >/dev/null
+  git config user.name observability-noctua-bot
+  git config user.email webops+observability-noctua-bot@canonical.com
+  git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/observability-noctua-bot/oci-factory.git"
+  branch_name="update-$(date -d now +%s)"
+  git checkout -b "$branch_name"
+  git add oci/{{rock_name}}/image.yaml
+  git commit -m "chore: Add new {{rock_name}} releases"
+  git push -u origin "$branch_name" --force
+  echo "✓ Changes have been pushed to ${branch_name}"
+  gh pr create --repo canonical/oci-factory \
+    --head "observability-noctua-bot:${branch_name}" \
+    --title "chore: Add new {{rock_name}} releases" \
+    --body "This is an automatic PR opened by the Observability Noctua bot."
+  popd >/dev/null
+  rm -rf "$TMP_DIR"
+  echo "✓ Release to OCI Factory completed"

--- a/rocks/istio-ztunnel-rock/spread.yaml
+++ b/rocks/istio-ztunnel-rock/spread.yaml
@@ -1,0 +1,41 @@
+project: rock
+
+backends:
+  craft:
+    type: craft
+    systems:
+      - ubuntu-24.04:
+      #- ubuntu-22.04:
+
+suites:
+  spread/general/:
+    summary: General integration tests
+    environment:
+      # Goss environment
+      GOSS_OPTS: "--retry-timeout=60s"
+      GOSS_FILES_STRATEGY: cp
+      DGOSS_TEMP_DIR: "$HOME"
+
+    prepare: |
+      # Install dependencies
+      sudo snap install docker
+      curl -fsSL https://goss.rocks/install | sh
+
+      # For 'rockcraft.skopeo'
+      sudo snap install --classic rockcraft
+
+      # Wait for docker daemon to come online
+      sudo apt install --yes retry
+      retry --times=10 --delay 2 -- docker run hello-world
+      sudo apt remove --yes retry
+
+      # Load the rock into docker
+      sudo rockcraft.skopeo --insecure-policy copy "oci-archive:$CRAFT_ARTIFACT" docker-daemon:rockcraft-test:latest
+      
+    restore: |
+      docker image rm --force rockcraft-test:latest
+
+exclude:
+  - .git
+
+kill-timeout: 1h


### PR DESCRIPTION
Rocks migration PR. The following rocks are covered

- [`istio-pilot`](https://github.com/canonical/istio-pilot-rock/)
- [`istio-ztunnel`](https://github.com/canonical/istio-ztunnel-rock/)
- [`istio-install-cni`](https://github.com/canonical/istio-install-cni-rock/)

The metrics-proxy rock was decided not be part of this monorepo. And the kiali-rock will be moved into this repo as a part of the kiali maintenance effort.

Also the rock workflows target the rocks/ folder and the workflow triggers testing and building of only the rocks that are touched.

There is no track branch based triggers. After talking with @lucabello, it was confirmed that rocks will always only be released from main anyway.