### PR TITLE
feat(canonical-service-mesh): adds utilities for envoy proxy charm

### DIFF
--- a/canonical_service_mesh/pyproject.toml
+++ b/canonical_service_mesh/pyproject.toml
@@ -20,12 +20,13 @@ classifiers = [
 dependencies = [
     "httpx",
     "lightkube>=0.11.0",
-    "ops>=2.5",
+    "ops>=2.23",
     "pydantic>=2",
 ]
 
 [dependency-groups]
 dev = [
+    "ops[testing]",
     "pytest",
     "pytest-cov",
     "ruff",

--- a/canonical_service_mesh/src/canonical_service_mesh/interfaces/envoy_extension_server/__init__.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/interfaces/envoy_extension_server/__init__.py
@@ -1,0 +1,83 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Envoy extension-server interface library.
+
+This library provides the provider and requirer sides of the
+``envoy-extension-server`` relation interface, which wires an Envoy Gateway
+control plane to a server implementing Envoy Gateway's
+`Extension Server <https://gateway.envoyproxy.io/docs/tasks/extensibility/extension-server/>`_
+protocol.
+
+What is this library for?
+=========================
+
+The ``envoy-controller-k8s`` charm runs the Envoy Gateway control plane. Envoy
+Gateway can delegate fine-tuning of its generated xDS to an external gRPC
+*extension server* — today, the Envoy AI Gateway controller
+(``envoy-ai-gateway-k8s``). To use it, Envoy Gateway must be configured with the
+extension server's address (``extensionManager.service.fqdn`` + port ``1063``)
+and the relevant ``xdsTranslator`` hooks. The control plane cannot know that
+address until the two charms are related — hence this interface.
+
+The relation is the on/off switch for the extension: when present, the control
+plane wires ``extensionManager`` to the provider's address; when absent, it runs
+plain. The provider (extension server) advertises its gRPC endpoint; the
+requirer (control plane) publishes its ``controllerName`` and namespace back so
+the provider can gate itself to the correct GatewayClass.
+
+Provider usage (extension server, e.g. the AI Gateway controller)::
+
+    from canonical_service_mesh.interfaces.envoy_extension_server import (
+        ExtensionServerProvider,
+    )
+
+    class MyExtensionServerCharm(CharmBase):
+        def __init__(self, framework):
+            super().__init__(framework)
+            self.ext_server = ExtensionServerProvider(self)
+
+        def _publish(self):
+            self.ext_server.publish_data(
+                extension_server_fqdn="my-ext-server.my-model.svc.cluster.local",
+                extension_server_port="1063",
+            )
+
+Requirer usage (Envoy Gateway control plane)::
+
+    from canonical_service_mesh.interfaces.envoy_extension_server import (
+        ExtensionServerRequirer,
+    )
+
+    class MyControlPlaneCharm(CharmBase):
+        def __init__(self, framework):
+            super().__init__(framework)
+            self.ext_server = ExtensionServerRequirer(self)
+
+        def _reconcile(self):
+            if self.ext_server.is_ready:
+                data = self.ext_server.get_extension_server_data()
+                # configure EG extensionManager with data.extension_server_fqdn/port
+            self.ext_server.publish_controller_identity(
+                controller_name="envoy-controller-k8s",
+                namespace=self.model.name,
+            )
+"""
+
+from ._envoy_extension_server import (
+    DEFAULT_EXTENSION_SERVER_PORT,
+    DEFAULT_RELATION_NAME,
+    ControllerIdentityData,
+    ExtensionServerData,
+    ExtensionServerProvider,
+    ExtensionServerRequirer,
+)
+
+__all__ = [
+    "DEFAULT_EXTENSION_SERVER_PORT",
+    "DEFAULT_RELATION_NAME",
+    "ControllerIdentityData",
+    "ExtensionServerData",
+    "ExtensionServerProvider",
+    "ExtensionServerRequirer",
+]

--- a/canonical_service_mesh/src/canonical_service_mesh/interfaces/envoy_extension_server/_envoy_extension_server.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/interfaces/envoy_extension_server/_envoy_extension_server.py
@@ -1,0 +1,219 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Envoy extension-server interface implementation.
+
+Wires an Envoy Gateway control plane (requirer) to a server that implements
+Envoy Gateway's Extension Server protocol (provider) — today, the Envoy AI
+Gateway controller. The provider advertises where its extension-server gRPC
+endpoint lives; the requirer consumes that to configure EG's ``extensionManager``
+and advertises its own controller identity back so the provider can gate itself.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ops.framework import Object
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+if TYPE_CHECKING:
+    from ops import CharmBase
+
+DEFAULT_RELATION_NAME = "envoy-extension-server"
+
+# Envoy Gateway's Extension Server protocol default gRPC port.
+DEFAULT_EXTENSION_SERVER_PORT = "1063"
+
+logger = logging.getLogger(__name__)
+
+
+class ExtensionServerData(BaseModel):
+    """Provider-side databag model for the envoy-extension-server relation.
+
+    Each field maps to a top-level key in the provider's application databag.
+    Use ``ops.Relation.load`` / ``ops.Relation.save`` to (de)serialise.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    extension_server_fqdn: str | None = Field(
+        default=None,
+        description="Cluster-internal FQDN of the extension-server gRPC service.",
+    )
+    extension_server_port: str | None = Field(
+        default=None,
+        description="Port of the extension-server gRPC service (Envoy Gateway default 1063).",
+    )
+
+    @field_validator("extension_server_port")
+    @classmethod
+    def _validate_port(cls, port: str | None) -> str | None:
+        if port is None:
+            return port
+        try:
+            int(port)
+        except ValueError:
+            msg = f"extension_server_port must be convertible to an integer, got {port!r}"
+            raise ValueError(msg) from None
+        return port
+
+
+class ControllerIdentityData(BaseModel):
+    """Requirer-side databag model for the envoy-extension-server relation.
+
+    Carries the Envoy Gateway control plane's identity so the provider can gate
+    itself to the correct GatewayClass and namespace.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    controller_name: str | None = Field(
+        default=None,
+        description="The Envoy Gateway controllerName / GatewayClass the extension targets.",
+    )
+    namespace: str | None = Field(
+        default=None,
+        description="The namespace the Envoy Gateway control plane runs in.",
+    )
+
+
+class ExtensionServerProvider(Object):
+    """Provider side of the envoy_extension_server interface.
+
+    Used by the extension server (e.g. the AI Gateway controller) to advertise
+    the address of its extension-server gRPC endpoint and to read the Envoy
+    Gateway control plane's identity from the requirer.
+    """
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ):
+        """Initialize the ExtensionServerProvider.
+
+        Args:
+            charm: The charm that owns this provider.
+            relation_name: Name of the relation (default: "envoy-extension-server").
+        """
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+
+    def publish_data(
+        self,
+        extension_server_fqdn: str,
+        extension_server_port: str = DEFAULT_EXTENSION_SERVER_PORT,
+    ) -> None:
+        """Publish the extension-server address to all related applications.
+
+        Args:
+            extension_server_fqdn: Cluster-internal FQDN of the extension-server gRPC service.
+            extension_server_port: Port of the extension-server gRPC service.
+        """
+        if not self._charm.unit.is_leader():
+            logger.debug("Not leader, skipping extension-server data publication")
+            return
+
+        data = ExtensionServerData(
+            extension_server_fqdn=extension_server_fqdn,
+            extension_server_port=extension_server_port,
+        )
+        for relation in self._charm.model.relations.get(self._relation_name, []):
+            relation.save(data, self._charm.app)
+
+    def get_controller_identity(self) -> ControllerIdentityData | None:
+        """Read the Envoy Gateway control plane's identity from the requirer.
+
+        Returns:
+            The requirer's ControllerIdentityData if a single relation has
+            published valid data, else None.
+        """
+        relations = self._charm.model.relations.get(self._relation_name, [])
+        for relation in relations:
+            if not relation.app:
+                continue
+            try:
+                return relation.load(ControllerIdentityData, relation.app)
+            except Exception:
+                logger.exception("Failed to parse controller identity from %s", relation.app.name)
+        return None
+
+
+class ExtensionServerRequirer(Object):
+    """Requirer side of the envoy_extension_server interface.
+
+    Used by the Envoy Gateway control plane to read the extension-server address
+    it must configure EG's ``extensionManager`` with, and to publish its own
+    controller identity so the provider can gate itself.
+    """
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ):
+        """Initialize the ExtensionServerRequirer.
+
+        Args:
+            charm: The charm that owns this requirer.
+            relation_name: Name of the relation (default: "envoy-extension-server").
+        """
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+
+    @property
+    def is_ready(self) -> bool:
+        """Whether the provider has published a usable extension-server address.
+
+        Returns:
+            True if the related provider has published both
+            extension_server_fqdn and extension_server_port.
+        """
+        return self.get_extension_server_data() is not None
+
+    def publish_controller_identity(
+        self,
+        controller_name: str,
+        namespace: str,
+    ) -> None:
+        """Publish this control plane's identity to all related applications.
+
+        Args:
+            controller_name: The EG controllerName / GatewayClass the extension targets.
+            namespace: The namespace the EG control plane runs in.
+        """
+        if not self._charm.unit.is_leader():
+            logger.debug("Not leader, skipping controller identity publication")
+            return
+
+        data = ControllerIdentityData(controller_name=controller_name, namespace=namespace)
+        for relation in self._charm.model.relations.get(self._relation_name, []):
+            relation.save(data, self._charm.app)
+
+    def get_extension_server_data(self) -> ExtensionServerData | None:
+        """Read the provider's extension-server address.
+
+        Only data with both ``extension_server_fqdn`` and
+        ``extension_server_port`` present is treated as ready.
+
+        Returns:
+            The provider's ExtensionServerData if available and complete, else None.
+        """
+        relations = self._charm.model.relations.get(self._relation_name, [])
+        for relation in relations:
+            if not relation.app:
+                continue
+            try:
+                data = relation.load(ExtensionServerData, relation.app)
+            except Exception:
+                logger.exception(
+                    "Failed to parse extension-server data from %s", relation.app.name
+                )
+                continue
+            if data.extension_server_fqdn and data.extension_server_port:
+                return data
+        return None

--- a/canonical_service_mesh/src/canonical_service_mesh/k8s/resource_manager/__init__.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/k8s/resource_manager/__init__.py
@@ -4,6 +4,7 @@
 """Kubernetes resource managers."""
 
 from ._batch_operations import apply_many, delete_many, patch_many
+from ._crd_manager import CustomResourceDefinitionManager
 from ._mocking import FakeApiError
 from ._resource_manager import (
     K8sApiError,
@@ -13,6 +14,7 @@ from ._resource_manager import (
 )
 
 __all__ = [
+    "CustomResourceDefinitionManager",
     "FakeApiError",
     "K8sApiError",
     "KubernetesResourceManager",

--- a/canonical_service_mesh/src/canonical_service_mesh/k8s/resource_manager/_crd_manager.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/k8s/resource_manager/_crd_manager.py
@@ -1,0 +1,91 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Manager for CustomResourceDefinition manifests."""
+
+import logging
+from typing import Optional
+
+from lightkube import ApiError, Client
+from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
+from ops import CharmBase
+
+from ..types import LightkubeResourcesList
+from ._resource_manager import KubernetesResourceManager, create_charm_default_labels
+
+_ESTABLISHED_CONDITION = "Established"
+
+
+class CustomResourceDefinitionManager:
+    """Manage a manifest of CustomResourceDefinitions and report when they are Established.
+
+    Composes a KubernetesResourceManager scoped to CustomResourceDefinition. Charms apply their
+    own CRD manifests through reconcile() and gate controller startup on established(); a charm
+    that does not need the readiness gate can simply skip the established() call.
+
+    Args:
+        charm: The charm instantiating this manager.
+        lightkube_client: Lightkube Client for all k8s operations.
+        scope: Label scope distinguishing this CRD set from others managed by the same charm.
+        logger: Logger for log output.
+    """
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        lightkube_client: Client,
+        scope: str,
+        logger: Optional[logging.Logger] = None,
+    ):
+        self.log = logger or logging.getLogger(__name__)
+        self._client = lightkube_client
+        self._krm = KubernetesResourceManager(
+            labels=create_charm_default_labels(charm.app.name, charm.model.name, scope=scope),
+            resource_types={CustomResourceDefinition},
+            lightkube_client=lightkube_client,
+            logger=self.log,
+        )
+
+    def reconcile(self, resources: LightkubeResourcesList) -> None:
+        """Reconcile the given CustomResourceDefinitions.
+
+        Args:
+            resources: The CustomResourceDefinition resources to apply.
+        """
+        self._krm.reconcile(resources)
+
+    def delete(self, ignore_missing: bool = True) -> None:
+        """Delete all CustomResourceDefinitions managed by this manager.
+
+        Args:
+            ignore_missing: Avoid raising 404 errors on deletion.
+        """
+        self._krm.delete(ignore_missing=ignore_missing)
+
+    def established(self, resources: LightkubeResourcesList) -> bool:
+        """Return True when every given CustomResourceDefinition reports Established.
+
+        A CRD is Established once the API server has accepted it and begun serving its resources;
+        creating custom resources before then races the API server and fails. A CRD that is
+        missing or briefly unqueryable (the API server returns 404/429 while freshly applied
+        CRDs initialise their storage) counts as not-yet-Established rather than an error, so a
+        caller can defer cleanly instead of flipping to error state.
+
+        Args:
+            resources: The CustomResourceDefinition resources to check.
+        """
+        for crd in resources:
+            name = crd.metadata.name  # pyright: ignore[reportAttributeAccessIssue]
+            try:
+                live = self._client.get(CustomResourceDefinition, name=name)
+            except ApiError:
+                self.log.debug("CRD %s not yet queryable", name)
+                return False
+            conditions = (live.status.conditions if live.status else None) or []
+            if not any(
+                condition.type == _ESTABLISHED_CONDITION and condition.status == "True"
+                for condition in conditions
+            ):
+                self.log.debug("CRD %s not yet Established", name)
+                return False
+        return True

--- a/canonical_service_mesh/src/canonical_service_mesh/k8s/types/envoy/__init__.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/k8s/types/envoy/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Envoy Gateway custom resource definitions."""
+
+from ._types import Backend, EnvoyProxy, SecurityPolicy
+
+__all__ = [
+    "Backend",
+    "EnvoyProxy",
+    "SecurityPolicy",
+]

--- a/canonical_service_mesh/src/canonical_service_mesh/k8s/types/envoy/_types.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/k8s/types/envoy/_types.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Envoy Gateway custom resource type definitions."""
+
+from typing import Type
+
+from lightkube.generic_resource import GenericNamespacedResource, create_namespaced_resource
+
+EnvoyProxy: Type[GenericNamespacedResource] = create_namespaced_resource(
+    "gateway.envoyproxy.io",
+    "v1alpha1",
+    "EnvoyProxy",
+    "envoyproxies",
+)
+
+Backend: Type[GenericNamespacedResource] = create_namespaced_resource(
+    "gateway.envoyproxy.io",
+    "v1alpha1",
+    "Backend",
+    "backends",
+)
+
+SecurityPolicy: Type[GenericNamespacedResource] = create_namespaced_resource(
+    "gateway.envoyproxy.io",
+    "v1alpha1",
+    "SecurityPolicy",
+    "securitypolicies",
+)

--- a/canonical_service_mesh/src/canonical_service_mesh/k8s/types/gateway_api/__init__.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/k8s/types/gateway_api/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Kubernetes Gateway API custom resource definitions."""
+
+from ._types import Gateway, GatewayClass, GRPCRoute, HTTPRoute, ReferenceGrant
+
+__all__ = [
+    "Gateway",
+    "GatewayClass",
+    "GRPCRoute",
+    "HTTPRoute",
+    "ReferenceGrant",
+]

--- a/canonical_service_mesh/src/canonical_service_mesh/k8s/types/gateway_api/_types.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/k8s/types/gateway_api/_types.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Kubernetes Gateway API custom resource type definitions."""
+
+from typing import Type
+
+from lightkube.generic_resource import (
+    GenericGlobalResource,
+    GenericNamespacedResource,
+    create_global_resource,
+    create_namespaced_resource,
+)
+
+# GatewayClass is cluster-scoped in the Gateway API, so it must be a global
+# resource; declaring it namespaced makes lightkube target a non-existent
+# /namespaces/<ns>/gatewayclasses path (404).
+GatewayClass: Type[GenericGlobalResource] = create_global_resource(
+    "gateway.networking.k8s.io",
+    "v1",
+    "GatewayClass",
+    "gatewayclasses",
+)
+
+Gateway: Type[GenericNamespacedResource] = create_namespaced_resource(
+    "gateway.networking.k8s.io",
+    "v1",
+    "Gateway",
+    "gateways",
+)
+
+HTTPRoute: Type[GenericNamespacedResource] = create_namespaced_resource(
+    "gateway.networking.k8s.io",
+    "v1",
+    "HTTPRoute",
+    "httproutes",
+)
+
+GRPCRoute: Type[GenericNamespacedResource] = create_namespaced_resource(
+    "gateway.networking.k8s.io",
+    "v1",
+    "GRPCRoute",
+    "grpcroutes",
+)
+
+ReferenceGrant: Type[GenericNamespacedResource] = create_namespaced_resource(
+    "gateway.networking.k8s.io",
+    "v1beta1",
+    "ReferenceGrant",
+    "referencegrants",
+)

--- a/canonical_service_mesh/src/canonical_service_mesh/models/__init__.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/models/__init__.py
@@ -6,6 +6,8 @@
 from ._gateway import (
     AllowedRoutes,
     BackendRef,
+    GatewayClassSpec,
+    GatewaySpec,
     GatewayTLSConfig,
     GRPCMethodMatch,
     GRPCRouteMatch,
@@ -20,6 +22,7 @@ from ._gateway import (
     IstioGatewayResource,
     IstioGatewaySpec,
     Listener,
+    ParametersRef,
     ParentRef,
     SecretObjectReference,
 )
@@ -28,6 +31,8 @@ from ._metadata import Metadata
 __all__ = [
     "AllowedRoutes",
     "BackendRef",
+    "GatewayClassSpec",
+    "GatewaySpec",
     "GatewayTLSConfig",
     "GRPCMethodMatch",
     "GRPCRouteMatch",
@@ -44,5 +49,6 @@ __all__ = [
     "Listener",
     "Metadata",
     "ParentRef",
+    "ParametersRef",
     "SecretObjectReference",
 ]

--- a/canonical_service_mesh/src/canonical_service_mesh/models/_gateway.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/models/_gateway.py
@@ -42,6 +42,32 @@ class Listener(BaseModel):
     tls: Optional[GatewayTLSConfig] = None
 
 
+class ParametersRef(BaseModel):
+    """ParametersRef references an implementation-specific resource for GatewayClass config."""
+
+    group: str
+    kind: str
+    name: str
+    namespace: Optional[str] = None
+
+
+class GatewayClassSpec(BaseModel):
+    """GatewayClassSpec defines the specification of a GatewayClass resource."""
+
+    controllerName: str  # noqa: N815
+    parametersRef: Optional[ParametersRef] = None  # noqa: N815
+
+
+class GatewaySpec(BaseModel):
+    """Generic GatewaySpec for any Gateway API implementation."""
+
+    gatewayClassName: str  # noqa: N815
+    listeners: List[Listener]
+    parametersRef: Optional[ParametersRef] = None  # noqa: N815
+
+
+# TODO: remove IstioGatewaySpec and IstioGatewayResource — use GatewaySpec instead.
+# Tracked in specs/envoy.spec.md Discussion Points.
 class IstioGatewaySpec(BaseModel):
     """GatewaySpec defines the specification of a gateway."""
 

--- a/canonical_service_mesh/src/canonical_service_mesh/models/envoy/__init__.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/models/envoy/__init__.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Envoy Gateway resource models."""
+
+from ._backend import (
+    BackendEndpoint,
+    BackendSpec,
+    FQDNEndpoint,
+)
+from ._envoy_proxy import (
+    EnvoyProxySpec,
+    JSONPatchOperation,
+    ProxyBootstrap,
+)
+from ._security_policy import (
+    BackendObjectRef,
+    ExtAuth,
+    ExtAuthHTTPService,
+    LocalPolicyTargetRef,
+    SecurityPolicySpec,
+)
+from ._telemetry import (
+    MetricsConfig,
+    MetricSink,
+    OpenTelemetrySink,
+    TelemetryConfig,
+)
+
+__all__ = [
+    "BackendEndpoint",
+    "BackendObjectRef",
+    "BackendSpec",
+    "EnvoyProxySpec",
+    "ExtAuth",
+    "ExtAuthHTTPService",
+    "FQDNEndpoint",
+    "JSONPatchOperation",
+    "LocalPolicyTargetRef",
+    "MetricSink",
+    "MetricsConfig",
+    "OpenTelemetrySink",
+    "ProxyBootstrap",
+    "SecurityPolicySpec",
+    "TelemetryConfig",
+]

--- a/canonical_service_mesh/src/canonical_service_mesh/models/envoy/_backend.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/models/envoy/_backend.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Envoy Gateway Backend resource models for Kubernetes."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class FQDNEndpoint(BaseModel):
+    """An FQDN-based endpoint for an Envoy Gateway Backend resource."""
+
+    hostname: str
+    port: int
+
+
+class BackendEndpoint(BaseModel):
+    """A single endpoint in an Envoy Gateway Backend resource."""
+
+    fqdn: Optional[FQDNEndpoint] = None
+
+
+class BackendSpec(BaseModel):
+    """Spec of an Envoy Gateway Backend resource."""
+
+    endpoints: List[BackendEndpoint]

--- a/canonical_service_mesh/src/canonical_service_mesh/models/envoy/_envoy_proxy.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/models/envoy/_envoy_proxy.py
@@ -1,0 +1,44 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""EnvoyProxy resource spec models for Kubernetes."""
+
+from typing import Any, List, Optional
+
+from pydantic import BaseModel
+
+from ._telemetry import TelemetryConfig
+
+
+class JSONPatchOperation(BaseModel):
+    """An RFC 6902 JSON Patch operation applied to the Envoy bootstrap."""
+
+    op: str
+    path: str
+    value: Optional[Any] = None
+
+
+class ProxyBootstrap(BaseModel):
+    """Override or patch the Envoy bootstrap of the managed proxy fleet.
+
+    Mirrors Envoy Gateway's ``ProxyBootstrap``: ``type`` selects the override
+    strategy (``Replace``, ``Merge``, or ``JSONPatch``); ``value`` is a full
+    bootstrap YAML string (for ``Replace``/``Merge``); ``jsonPatches`` is a list
+    of RFC 6902 operations applied to the default bootstrap (for ``JSONPatch``).
+    """
+
+    type: Optional[str] = None
+    value: Optional[str] = None
+    jsonPatches: Optional[List[JSONPatchOperation]] = None  # noqa: N815
+
+
+class EnvoyProxySpec(BaseModel):
+    """Spec of a default EnvoyProxy resource.
+
+    Carries an optional Envoy bootstrap override (e.g. to inject fixed
+    Juju-topology stats tags via a JSON patch) and an optional OpenTelemetry
+    metrics sink.
+    """
+
+    bootstrap: Optional[ProxyBootstrap] = None
+    telemetry: Optional[TelemetryConfig] = None

--- a/canonical_service_mesh/src/canonical_service_mesh/models/envoy/_security_policy.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/models/envoy/_security_policy.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Envoy Gateway SecurityPolicy resource models for Kubernetes."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class LocalPolicyTargetRef(BaseModel):
+    """A local (same-namespace) reference to a policy target resource."""
+
+    group: str
+    kind: str
+    name: str
+
+
+class BackendObjectRef(BaseModel):
+    """A typed backend reference pointing at a specific group/kind resource."""
+
+    group: str
+    kind: str
+    name: str
+    namespace: Optional[str] = None
+
+
+class ExtAuthHTTPService(BaseModel):
+    """HTTP-based ext auth service configuration."""
+
+    backendRefs: List[BackendObjectRef]  # noqa: N815
+    path: Optional[str] = None
+
+
+class ExtAuth(BaseModel):
+    """External authentication configuration for a SecurityPolicy."""
+
+    http: Optional[ExtAuthHTTPService] = None
+
+
+class SecurityPolicySpec(BaseModel):
+    """Spec of an Envoy Gateway SecurityPolicy resource."""
+
+    targetRef: LocalPolicyTargetRef  # noqa: N815
+    extAuth: Optional[ExtAuth] = None  # noqa: N815

--- a/canonical_service_mesh/src/canonical_service_mesh/models/envoy/_telemetry.py
+++ b/canonical_service_mesh/src/canonical_service_mesh/models/envoy/_telemetry.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Envoy Gateway shared telemetry models for Kubernetes."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class OpenTelemetrySink(BaseModel):
+    """An OpenTelemetry metrics sink target (host + port).
+
+    Matches the Envoy Gateway ``openTelemetry`` metric sink schema used by both
+    ``EnvoyGateway.telemetry`` (control plane) and ``EnvoyProxy.spec.telemetry``
+    (data plane).
+    """
+
+    host: str
+    port: int
+
+
+class MetricSink(BaseModel):
+    """A single Envoy Gateway metrics sink entry."""
+
+    type: str = "OpenTelemetry"
+    openTelemetry: OpenTelemetrySink  # noqa: N815
+
+
+class MetricsConfig(BaseModel):
+    """Envoy metrics configuration carrying one or more sinks."""
+
+    sinks: List[MetricSink] = Field(default_factory=list)
+
+
+class TelemetryConfig(BaseModel):
+    """Envoy telemetry configuration."""
+
+    metrics: Optional[MetricsConfig] = None

--- a/canonical_service_mesh/tests/unit/interfaces/test_envoy_extension_server.py
+++ b/canonical_service_mesh/tests/unit/interfaces/test_envoy_extension_server.py
@@ -1,0 +1,169 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for the envoy-extension-server interface library."""
+
+from __future__ import annotations
+
+import json
+
+import ops
+import pytest
+from ops.charm import CharmBase
+from ops.testing import Context, Relation, State
+
+from canonical_service_mesh.interfaces.envoy_extension_server import (
+    ExtensionServerData,
+    ExtensionServerProvider,
+    ExtensionServerRequirer,
+)
+
+PROVIDER_META = {
+    "name": "provider-charm",
+    "provides": {"envoy-extension-server": {"interface": "envoy_extension_server"}},
+}
+
+REQUIRER_META = {
+    "name": "requirer-charm",
+    "requires": {"envoy-extension-server": {"interface": "envoy_extension_server"}},
+}
+
+
+class ProviderCharm(CharmBase):
+    def __init__(self, framework: ops.Framework):
+        super().__init__(framework)
+        self.ext_server = ExtensionServerProvider(self)
+        self.framework.observe(
+            self.on["envoy-extension-server"].relation_changed, self._on_changed
+        )
+
+    def _on_changed(self, _: ops.EventBase) -> None:
+        self.ext_server.publish_data(
+            extension_server_fqdn="ai.my-model.svc.cluster.local",
+        )
+
+
+class RequirerCharm(CharmBase):
+    def __init__(self, framework: ops.Framework):
+        super().__init__(framework)
+        self.ext_server = ExtensionServerRequirer(self)
+        self.framework.observe(
+            self.on["envoy-extension-server"].relation_changed, self._on_changed
+        )
+
+    def _on_changed(self, _: ops.EventBase) -> None:
+        self.ext_server.publish_controller_identity(
+            controller_name="envoy-controller-k8s",
+            namespace="my-model",
+        )
+
+
+def _provider_databag(fqdn: str = "ai.my-model.svc.cluster.local", port: str = "1063"):
+    return {
+        "extension_server_fqdn": json.dumps(fqdn),
+        "extension_server_port": json.dumps(port),
+    }
+
+
+def test_provider_publishes_extension_server_address():
+    relation = Relation(endpoint="envoy-extension-server", interface="envoy_extension_server")
+    ctx = Context(ProviderCharm, meta=PROVIDER_META)
+    state_out = ctx.run(
+        ctx.on.relation_changed(relation=relation),
+        State(relations=[relation], leader=True),
+    )
+    rel_out = state_out.get_relation(relation.id)
+    assert json.loads(rel_out.local_app_data["extension_server_fqdn"]) == (
+        "ai.my-model.svc.cluster.local"
+    )
+    assert json.loads(rel_out.local_app_data["extension_server_port"]) == "1063"
+
+
+def test_provider_skips_publish_when_not_leader():
+    relation = Relation(endpoint="envoy-extension-server", interface="envoy_extension_server")
+    ctx = Context(ProviderCharm, meta=PROVIDER_META)
+    state_out = ctx.run(
+        ctx.on.relation_changed(relation=relation),
+        State(relations=[relation], leader=False),
+    )
+    rel_out = state_out.get_relation(relation.id)
+    assert "extension_server_fqdn" not in rel_out.local_app_data
+
+
+def test_requirer_publishes_controller_identity():
+    relation = Relation(endpoint="envoy-extension-server", interface="envoy_extension_server")
+    ctx = Context(RequirerCharm, meta=REQUIRER_META)
+    state_out = ctx.run(
+        ctx.on.relation_changed(relation=relation),
+        State(relations=[relation], leader=True),
+    )
+    rel_out = state_out.get_relation(relation.id)
+    assert json.loads(rel_out.local_app_data["controller_name"]) == "envoy-controller-k8s"
+    assert json.loads(rel_out.local_app_data["namespace"]) == "my-model"
+
+
+def test_requirer_reads_provider_address():
+    relation = Relation(
+        endpoint="envoy-extension-server",
+        interface="envoy_extension_server",
+        remote_app_name="ai-charm",
+        remote_app_data=_provider_databag(),
+    )
+    ctx = Context(RequirerCharm, meta=REQUIRER_META)
+    with ctx(
+        ctx.on.relation_changed(relation=relation),
+        State(relations=[relation], leader=True),
+    ) as mgr:
+        data = mgr.charm.ext_server.get_extension_server_data()
+        assert data is not None
+        assert data.extension_server_fqdn == "ai.my-model.svc.cluster.local"
+        assert data.extension_server_port == "1063"
+        assert mgr.charm.ext_server.is_ready is True
+
+
+def test_requirer_not_ready_without_relation():
+    ctx = Context(RequirerCharm, meta=REQUIRER_META)
+    with ctx(ctx.on.start(), State(leader=True)) as mgr:
+        assert mgr.charm.ext_server.is_ready is False
+        assert mgr.charm.ext_server.get_extension_server_data() is None
+
+
+def test_requirer_not_ready_with_partial_provider_data():
+    relation = Relation(
+        endpoint="envoy-extension-server",
+        interface="envoy_extension_server",
+        remote_app_name="ai-charm",
+        remote_app_data={"extension_server_fqdn": json.dumps("ai.my-model.svc.cluster.local")},
+    )
+    ctx = Context(RequirerCharm, meta=REQUIRER_META)
+    with ctx(
+        ctx.on.relation_changed(relation=relation),
+        State(relations=[relation], leader=True),
+    ) as mgr:
+        assert mgr.charm.ext_server.is_ready is False
+
+
+def test_provider_reads_controller_identity():
+    relation = Relation(
+        endpoint="envoy-extension-server",
+        interface="envoy_extension_server",
+        remote_app_name="eg-charm",
+        remote_app_data={
+            "controller_name": json.dumps("envoy-controller-k8s"),
+            "namespace": json.dumps("my-model"),
+        },
+    )
+    ctx = Context(ProviderCharm, meta=PROVIDER_META)
+    with ctx(
+        ctx.on.relation_changed(relation=relation),
+        State(relations=[relation], leader=True),
+    ) as mgr:
+        identity = mgr.charm.ext_server.get_controller_identity()
+        assert identity is not None
+        assert identity.controller_name == "envoy-controller-k8s"
+        assert identity.namespace == "my-model"
+
+
+def test_port_validation_rejects_non_integer():
+    with pytest.raises(ValueError, match="convertible to an integer"):
+        ExtensionServerData(extension_server_port="not-a-number")

--- a/canonical_service_mesh/tests/unit/test_crd_manager.py
+++ b/canonical_service_mesh/tests/unit/test_crd_manager.py
@@ -1,0 +1,96 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from unittest.mock import MagicMock
+
+import pytest
+from lightkube.models.apiextensions_v1 import (
+    CustomResourceDefinitionCondition,
+    CustomResourceDefinitionNames,
+    CustomResourceDefinitionSpec,
+    CustomResourceDefinitionStatus,
+)
+from lightkube.models.meta_v1 import ObjectMeta
+from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
+
+from canonical_service_mesh.k8s.resource_manager import (
+    CustomResourceDefinitionManager,
+    FakeApiError,
+)
+
+_SPEC = CustomResourceDefinitionSpec(
+    group="example.com",
+    names=CustomResourceDefinitionNames(kind="Widget", plural="widgets"),
+    scope="Cluster",
+    versions=[],
+)
+
+
+def _crd(name):
+    return CustomResourceDefinition(metadata=ObjectMeta(name=name), spec=_SPEC)
+
+
+def _live_crd(name, conditions):
+    status = (
+        CustomResourceDefinitionStatus(conditions=conditions) if conditions is not None else None
+    )
+    return CustomResourceDefinition(metadata=ObjectMeta(name=name), spec=_SPEC, status=status)
+
+
+def _condition(type_, status):
+    return CustomResourceDefinitionCondition(type=type_, status=status)
+
+
+def _manager(client):
+    charm = MagicMock()
+    charm.app.name = "app"
+    charm.model.name = "model"
+    return CustomResourceDefinitionManager(charm, client, scope="crds")
+
+
+@pytest.mark.parametrize(
+    "conditions, expected",
+    [
+        ([_condition("Established", "True")], True),
+        ([_condition("NamesAccepted", "True"), _condition("Established", "True")], True),
+        ([_condition("Established", "False")], False),
+        ([_condition("NamesAccepted", "True")], False),
+        ([], False),
+        (None, False),
+    ],
+)
+def test_established_reads_condition(conditions, expected):
+    client = MagicMock()
+    client.get.return_value = _live_crd("widgets.example.com", conditions)
+    manager = _manager(client)
+
+    assert manager.established([_crd("widgets.example.com")]) is expected
+
+
+def test_established_requires_every_crd():
+    established = _live_crd("a.example.com", [_condition("Established", "True")])
+    pending = _live_crd("b.example.com", [_condition("Established", "False")])
+    client = MagicMock()
+    client.get.side_effect = [established, pending]
+    manager = _manager(client)
+
+    assert manager.established([_crd("a.example.com"), _crd("b.example.com")]) is False
+
+
+@pytest.mark.parametrize("code", [404, 429], ids=["not-present", "initialising"])
+def test_established_treats_api_error_as_not_established(code):
+    client = MagicMock()
+    client.get.side_effect = FakeApiError(code)
+    manager = _manager(client)
+
+    assert manager.established([_crd("widgets.example.com")]) is False
+
+
+def test_reconcile_delegates_to_krm():
+    manager = _manager(MagicMock())
+    manager._krm = MagicMock()
+    resources = [_crd("widgets.example.com")]
+
+    manager.reconcile(resources)
+
+    manager._krm.reconcile.assert_called_once_with(resources)

--- a/canonical_service_mesh/tests/unit/test_envoy_models.py
+++ b/canonical_service_mesh/tests/unit/test_envoy_models.py
@@ -1,0 +1,257 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for canonical_service_mesh envoy models.
+
+These tests focus on serialisation shape — verifying that
+``model_dump(by_alias=True, exclude_none=True)`` produces the exact JSON
+structure that Envoy Gateway / Kubernetes expects.  Shape regressions (e.g.
+renaming ``endpoint`` → ``host``/``port``) are caught here.
+"""
+
+from canonical_service_mesh.models import (
+    AllowedRoutes,
+    GatewayClassSpec,
+    GatewaySpec,
+    GatewayTLSConfig,
+    Listener,
+    ParametersRef,
+    SecretObjectReference,
+)
+from canonical_service_mesh.models.envoy import (
+    BackendEndpoint,
+    BackendObjectRef,
+    BackendSpec,
+    EnvoyProxySpec,
+    ExtAuth,
+    ExtAuthHTTPService,
+    FQDNEndpoint,
+    JSONPatchOperation,
+    LocalPolicyTargetRef,
+    MetricsConfig,
+    MetricSink,
+    OpenTelemetrySink,
+    ProxyBootstrap,
+    SecurityPolicySpec,
+    TelemetryConfig,
+)
+
+# ---- OpenTelemetry sink shape ----
+
+
+def test_otel_sink_uses_host_and_port_not_endpoint():
+    """Envoy Gateway metric sink schema requires host+port, not a URL."""
+    sink = OpenTelemetrySink(host="otel.observability.svc", port=4318)
+    data = sink.model_dump(by_alias=True)
+    assert "host" in data and "port" in data
+    assert "endpoint" not in data
+
+
+def test_metric_sink_serialised_shape():
+    """MetricSink serialises to the shape Envoy Gateway expects."""
+    sink = MetricSink(openTelemetry=OpenTelemetrySink(host="collector", port=4318))
+    data = sink.model_dump(by_alias=True, exclude_none=True)
+    assert data == {
+        "type": "OpenTelemetry",
+        "openTelemetry": {"host": "collector", "port": 4318},
+    }
+
+
+def test_telemetry_config_omits_metrics_when_none():
+    data = TelemetryConfig(metrics=None).model_dump(exclude_none=True)
+    assert "metrics" not in data
+
+
+# ---- EnvoyProxy spec — the full Juju-topology + OTLP shape ----
+
+
+def test_envoy_proxy_spec_full_shape():
+    """Full EnvoyProxy spec serialises correctly for KRM reconcile.
+
+    Fixed stats tags are injected via a JSONPatch on the Envoy bootstrap, since
+    the EnvoyProxy CRD has no native stats-tags field — the only schema-valid way
+    to add them is patching the bootstrap's ``stats_config.stats_tags``.
+    """
+    spec = EnvoyProxySpec(
+        bootstrap=ProxyBootstrap(
+            type="JSONPatch",
+            jsonPatches=[
+                JSONPatchOperation(
+                    op="add",
+                    path="/stats_config/stats_tags/-",
+                    value={"tag_name": "juju_model", "fixed_value": "my-model"},
+                ),
+                JSONPatchOperation(
+                    op="add",
+                    path="/stats_config/stats_tags/-",
+                    value={"tag_name": "juju_charm", "fixed_value": "envoy-controller-k8s"},
+                ),
+            ],
+        ),
+        telemetry=TelemetryConfig(
+            metrics=MetricsConfig(
+                sinks=[MetricSink(openTelemetry=OpenTelemetrySink(host="otel", port=4318))]
+            )
+        ),
+    )
+    data = spec.model_dump(by_alias=True, exclude_none=True)
+
+    assert data["bootstrap"]["type"] == "JSONPatch"
+    patches = data["bootstrap"]["jsonPatches"]
+    assert all(p["op"] == "add" for p in patches)
+    assert all(p["path"] == "/stats_config/stats_tags/-" for p in patches)
+    tags = {p["value"]["tag_name"]: p["value"]["fixed_value"] for p in patches}
+    assert tags == {
+        "juju_model": "my-model",
+        "juju_charm": "envoy-controller-k8s",
+    }
+    assert data["telemetry"]["metrics"]["sinks"][0]["openTelemetry"]["host"] == "otel"
+
+
+def test_envoy_proxy_spec_omits_telemetry_when_no_otlp():
+    """When OTLP is not related, telemetry must be absent from the spec."""
+    spec = EnvoyProxySpec(
+        bootstrap=ProxyBootstrap(
+            type="JSONPatch",
+            jsonPatches=[
+                JSONPatchOperation(
+                    op="add",
+                    path="/stats_config/stats_tags/-",
+                    value={"tag_name": "juju_model", "fixed_value": "m"},
+                )
+            ],
+        )
+    )
+    data = spec.model_dump(by_alias=True, exclude_none=True)
+    assert "telemetry" not in data
+
+
+# ---- Backend spec ----
+
+
+def test_backend_spec_fqdn_shape():
+    """Backend spec serialises external hostname correctly for SecurityPolicy backendRef."""
+    spec = BackendSpec(
+        endpoints=[BackendEndpoint(fqdn=FQDNEndpoint(hostname="auth.example.com", port=4180))]
+    )
+    data = spec.model_dump(by_alias=True, exclude_none=True)
+    assert data == {"endpoints": [{"fqdn": {"hostname": "auth.example.com", "port": 4180}}]}
+
+
+# ---- SecurityPolicy spec ----
+
+
+def test_security_policy_spec_full_shape():
+    """SecurityPolicy with extAuth serialises to the shape Envoy Gateway expects."""
+    spec = SecurityPolicySpec(
+        targetRef=LocalPolicyTargetRef(
+            group="gateway.networking.k8s.io",
+            kind="Gateway",
+            name="envoy-ingress",
+        ),
+        extAuth=ExtAuth(
+            http=ExtAuthHTTPService(
+                backendRefs=[
+                    BackendObjectRef(
+                        group="gateway.envoyproxy.io",
+                        kind="Backend",
+                        name="forward-auth-backend",
+                        namespace="default",
+                    )
+                ],
+                path="/check",
+            )
+        ),
+    )
+    data = spec.model_dump(by_alias=True, exclude_none=True)
+    assert data["targetRef"] == {
+        "group": "gateway.networking.k8s.io",
+        "kind": "Gateway",
+        "name": "envoy-ingress",
+    }
+    assert data["extAuth"]["http"]["backendRefs"][0]["name"] == "forward-auth-backend"
+    assert data["extAuth"]["http"]["path"] == "/check"
+
+
+def test_security_policy_spec_omits_ext_auth_when_none():
+    spec = SecurityPolicySpec(
+        targetRef=LocalPolicyTargetRef(
+            group="gateway.networking.k8s.io", kind="Gateway", name="gw"
+        )
+    )
+    data = spec.model_dump(exclude_none=True)
+    assert "extAuth" not in data
+
+
+def test_backend_object_ref_omits_namespace_when_none():
+    ref = BackendObjectRef(group="gateway.envoyproxy.io", kind="Backend", name="b")
+    data = ref.model_dump(exclude_none=True)
+    assert "namespace" not in data
+
+
+# ---- Gateway model additions ----
+
+
+def test_gateway_class_spec_with_parameters_ref():
+    """GatewayClassSpec with parametersRef pointing at EnvoyProxy serialises correctly."""
+    spec = GatewayClassSpec(
+        controllerName="gateway.envoyproxy.io/gatewayclass-controller",
+        parametersRef=ParametersRef(
+            group="gateway.envoyproxy.io",
+            kind="EnvoyProxy",
+            name="envoy-default",
+            namespace="envoy-gateway-system",
+        ),
+    )
+    data = spec.model_dump(by_alias=True, exclude_none=True)
+    assert data["controllerName"] == "gateway.envoyproxy.io/gatewayclass-controller"
+    assert data["parametersRef"]["name"] == "envoy-default"
+    assert data["parametersRef"]["namespace"] == "envoy-gateway-system"
+
+
+def test_gateway_class_spec_omits_parameters_ref_when_none():
+    spec = GatewayClassSpec(controllerName="gateway.envoyproxy.io/gatewayclass-controller")
+    data = spec.model_dump(exclude_none=True)
+    assert "parametersRef" not in data
+
+
+def test_gateway_spec_http_listener_shape():
+    """GatewaySpec with HTTP listener serialises correctly for KRM reconcile."""
+    spec = GatewaySpec(
+        gatewayClassName="envoy",
+        listeners=[
+            Listener(
+                name="http",
+                port=80,
+                protocol="HTTP",
+                allowedRoutes=AllowedRoutes(namespaces={"from": "All"}),
+            )
+        ],
+    )
+    data = spec.model_dump(by_alias=True, exclude_none=True)
+    assert data["gatewayClassName"] == "envoy"
+    assert data["listeners"][0]["port"] == 80
+    assert "parametersRef" not in data
+
+
+def test_gateway_spec_https_listener_includes_tls_secret():
+    spec = GatewaySpec(
+        gatewayClassName="envoy",
+        listeners=[
+            Listener(
+                name="https",
+                port=443,
+                protocol="HTTPS",
+                allowedRoutes=AllowedRoutes(namespaces={"from": "All"}),
+                tls=GatewayTLSConfig(
+                    certificateRefs=[
+                        SecretObjectReference(kind="Secret", name="my-tls", namespace="default")
+                    ]
+                ),
+            )
+        ],
+    )
+    data = spec.model_dump(by_alias=True, exclude_none=True)
+    cert = data["listeners"][0]["tls"]["certificateRefs"][0]
+    assert cert["name"] == "my-tls"
+    assert cert["namespace"] == "default"

--- a/canonical_service_mesh/uv.lock
+++ b/canonical_service_mesh/uv.lock
@@ -37,6 +37,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "ops", extra = ["testing"] },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -47,12 +48,13 @@ dev = [
 requires-dist = [
     { name = "httpx" },
     { name = "lightkube", specifier = ">=0.11.0" },
-    { name = "ops", specifier = ">=2.5" },
+    { name = "ops", specifier = ">=2.23" },
     { name = "pydantic", specifier = ">=2" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "ops", extras = ["testing"] },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -367,6 +369,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7b/af/57895c8b7c23bf98e07d6306d24d2775a1e89fc2a4c8c1bd934dba3acdc2/ops-3.7.0.tar.gz", hash = "sha256:15f04b2fcf1d8bc966cd4405b68a2c71fa24c06f234d5003e89cc4f18ee51a45", size = 580141, upload-time = "2026-03-30T05:17:16.285Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/b0/19722b4b51696fbca41d3454f3dd3a73e89951303487b47280c6f3e277d4/ops-3.7.0-py3-none-any.whl", hash = "sha256:7050d5e629ac17de9d443e64f4ad09857e8012c9012c8ba66c9e765899d50bd1", size = 211865, upload-time = "2026-03-30T05:17:11.644Z" },
+]
+
+[package.optional-dependencies]
+testing = [
+    { name = "ops-scenario" },
+]
+
+[[package]]
+name = "ops-scenario"
+version = "8.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ops" },
+    { name = "pyyaml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/38/389a21258f32ecb3513686de889cdea9b02753cfa7f2becff4cef7e6350f/ops_scenario-8.7.0.tar.gz", hash = "sha256:0f17bbcac19e31cd0a408542c517fb22cf532bda1dc4f6133e50bafae0901e41", size = 78410, upload-time = "2026-03-30T05:17:17.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/f1/f292922d8ff9273fbc51b42aedfcde30cc7d76b40fc620ed2421028fa854/ops_scenario-8.7.0-py3-none-any.whl", hash = "sha256:2245bf9127e2f455d05ee0e75345a86fa83cbd44aaa253320aeb0d68433e34de", size = 69231, upload-time = "2026-03-30T05:17:13.334Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds the required utility models and dataclasses to support the new envoy charms,

Tandem PRs
- #104 
- #114 
- #115 