### PR TITLE
Fix discoverability blockers

### DIFF
--- a/charms/istio-beacon-k8s/tox.ini
+++ b/charms/istio-beacon-k8s/tox.ini
@@ -34,8 +34,12 @@ commands =
 
 [testenv:lint]
 description = Lint the code
+allowlist_externals =
+  {[testenv]allowlist_externals}
+  /usr/bin/env
 commands =
     uv run {[vars]uv_flags} ruff check {[vars]all_path} --exclude={[vars]tester_lib_path}
+    {[testenv:static]commands}
 
 [testenv:static]
 description = Run static checks
@@ -50,6 +54,11 @@ commands =
 description = "Format the code"
 commands =
     uv run {[vars]uv_flags} ruff check --fix-only {[vars]all_path} --exclude={[vars]tester_lib_path}
+
+[testenv:format]
+description = "Format the code (alias for fmt)"
+commands =
+    {[testenv:fmt]commands}
 
 [testenv:unit]
 description = Run unit tests

--- a/charms/istio-ingress-k8s/tox.ini
+++ b/charms/istio-ingress-k8s/tox.ini
@@ -36,10 +36,19 @@ description = "Format the code"
 commands =
     uv run {[vars]uv_flags} ruff check --fix-only {[vars]all_path}
 
+[testenv:format]
+description = "Format the code (alias for fmt)"
+commands =
+    {[testenv:fmt]commands}
+
 [testenv:lint]
 description = Lint the code
+allowlist_externals =
+  {[testenv]allowlist_externals}
+  /usr/bin/env
 commands =
     uv run {[vars]uv_flags} ruff check {[vars]all_path}
+    {[testenv:static]commands}
 
 [testenv:unit]
 description = Run unit tests

--- a/charms/istio-ingress-k8s/tox.ini
+++ b/charms/istio-ingress-k8s/tox.ini
@@ -10,7 +10,7 @@ min_version = 4.0.0
 [vars]
 src_path = {tox_root}/src
 tests_path = {tox_root}/tests
-;lib_path = {tox_root}/lib/charms/operator_name_with_underscores
+lib_path = {tox_root}/lib/charms/istio_ingress_k8s
 all_path = {[vars]src_path} {[vars]tests_path}
 uv_flags = --frozen --isolated --extra=dev
 

--- a/charms/istio-k8s/charmcraft.yaml
+++ b/charms/istio-k8s/charmcraft.yaml
@@ -45,13 +45,13 @@ config:
         specify the platform-specific configuration for the Kubernetes platform on which the charm is deployed.  If left
         blank, no value of `values.global.platform` will be set.
 
-    cniBinDir:
+    cni-bin-dir:
       type: string
       default: ""
       description: >
         On some non-standard Kubernetes installation, certain files are not located in standard locations. This configuration option allows overriding those paths. It maps to the `values.cni.cniBinDir` field in the Istio Helm chart.
 
-    cniConfDir:
+    cni-conf-dir:
       type: string
       default: ""
       description: >

--- a/charms/istio-k8s/src/charm.py
+++ b/charms/istio-k8s/src/charm.py
@@ -567,10 +567,10 @@ class IstioCoreCharm(ops.CharmBase):
         # Ignore the settings if they are not set or empty
         if self.parsed_config["platform"]:
             setting_overrides["values.global.platform"] = self.parsed_config["platform"]
-        if self.parsed_config["cniBinDir"]:
-            setting_overrides["values.cni.cniBinDir"] = self.parsed_config["cniBinDir"]
-        if self.parsed_config["cniConfDir"]:
-            setting_overrides["values.cni.cniConfDir"] = self.parsed_config["cniConfDir"]
+        if self.parsed_config["cni-bin-dir"]:
+            setting_overrides["values.cni.cniBinDir"] = self.parsed_config["cni-bin-dir"]
+        if self.parsed_config["cni-conf-dir"]:
+            setting_overrides["values.cni.cniConfDir"] = self.parsed_config["cni-conf-dir"]
 
         # Configure the sidecar injector to exclude outbound traffic to all IP ranges.  This is a
         # workaround for CNI limitations with init containers

--- a/charms/istio-k8s/src/config.py
+++ b/charms/istio-k8s/src/config.py
@@ -7,7 +7,7 @@ class CharmConfig(BaseModel):
     """Manager for the charm configuration."""
 
     platform: str = Field()  # type: ignore
-    cniBinDir: str = Field()  # noqa: N815 (Mixed Case)
-    cniConfDir: str = Field()  # noqa: N815 (Mixed Case)
+    cni_bin_dir: str = Field(alias="cni-bin-dir")  # type: ignore
+    cni_conf_dir: str = Field(alias="cni-conf-dir")  # type: ignore
     auto_allow_waypoint_policy: bool = Field(alias="auto-allow-waypoint-policy")  # type: ignore
     hardened_mode: bool = Field(alias="hardened-mode")  # type: ignore

--- a/charms/istio-k8s/tests/unit/test_ca_cert.py
+++ b/charms/istio-k8s/tests/unit/test_ca_cert.py
@@ -102,8 +102,8 @@ def test_get_istioctl_without_ca(istio_core_context):
         charm: IstioCoreCharm = mgr.charm
         with patch.object(type(charm), "parsed_config", new_callable=lambda: property(lambda self: {
             "platform": "microk8s",
-            "cniBinDir": "",
-            "cniConfDir": "",
+            "cni-bin-dir": "",
+            "cni-conf-dir": "",
             "auto-allow-waypoint-policy": True,
         })):
             ictl = charm._get_istioctl()
@@ -118,8 +118,8 @@ def test_get_istioctl_with_ca(istio_core_context, jwks_ca_cert_relation_single):
         charm: IstioCoreCharm = mgr.charm
         with patch.object(type(charm), "parsed_config", new_callable=lambda: property(lambda self: {
             "platform": "microk8s",
-            "cniBinDir": "",
-            "cniConfDir": "",
+            "cni-bin-dir": "",
+            "cni-conf-dir": "",
             "auto-allow-waypoint-policy": True,
         })):
             ictl = charm._get_istioctl()

--- a/charms/istio-k8s/tox.ini
+++ b/charms/istio-k8s/tox.ini
@@ -31,10 +31,19 @@ description = Apply coding style standards to code
 commands =
   uv run {[vars]uv_flags} ruff check --fix-only {[vars]all_path}
 
+[testenv:format]
+description = Apply coding style standards to code (alias for fmt)
+commands =
+  {[testenv:fmt]commands}
+
 [testenv:lint]
 description = Check code against coding style standards
+allowlist_externals =
+  {[testenv]allowlist_externals}
+  /usr/bin/env
 commands =
   uv run {[vars]uv_flags} ruff check {[vars]all_path}
+  {[testenv:static]commands}
 
 [testenv:static]
 skip_install=True


### PR DESCRIPTION
1) This PR addresses review comments that are blockers for charm discoverability:

> *   We ask that tox (or make or whatever) has a `format` command. You can leave `fmt` as an alias if you like. Ideally, `lint` does type checking as well as other linting, again `static` can be left that only does it if preferred. This makes it easier to test charms at scale.
> *   **Mixed config naming** (`cniBinDir`/`cniConfDir` camelCase).

The full reviews can be found here:
https://github.com/canonical/charmhub-listing-review/issues/123#issuecomment-4698192598
https://github.com/canonical/charmhub-listing-review/issues/122#issuecomment-4698209437

2) There was an undefined `lib_path` variable in `istio-ingress-k8s`'  tox.ini files. Now, it is defined with the required path.

---

**Sidenote:** I noticed that some tests can not resolve dependencies on python 3.14.4. I will open an issue or a PR depending on the exact cause.