### PR TITLE
fix: lower the update status interval

### DIFF
--- a/charms/istio-k8s/tests/integration/model-config.yaml
+++ b/charms/istio-k8s/tests/integration/model-config.yaml
@@ -1,0 +1,1 @@
+update-status-hook-interval: 30s

--- a/charms/istio-k8s/tox.ini
+++ b/charms/istio-k8s/tox.ini
@@ -55,7 +55,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 commands =
-  uv run {[vars]uv_flags} pytest --exitfirst {[vars]tst_path}/integration {posargs}
+  uv run {[vars]uv_flags} pytest --exitfirst --model-config {[vars]tst_path}/integration/model-config.yaml {[vars]tst_path}/integration {posargs}
 
 [testenv:check]
 skip_install=True


### PR DESCRIPTION
Lower the update status interval so we don't [get stuck waiting for the CNI](https://github.com/canonical/service-mesh/actions/runs/28960684005/job/85971957517).