### PR TITLE
Listener hostnames

### DIFF
--- a/charms/istio-ingress-k8s/.tfdocs.yaml
+++ b/charms/istio-ingress-k8s/.tfdocs.yaml
@@ -1,0 +1,41 @@
+# https://terraform-docs.io/user-guide/configuration/
+
+formatter: markdown table
+
+sections:
+  show:
+    - requirements
+    - modules
+    - providers
+    - inputs
+    - outputs
+
+# This allows us to customize the injected docs
+content: ""
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  # anchor: true
+  color: true
+  default: true
+  description: true
+  # escape: true
+  # hide-empty: false
+  # html: true
+  # indent: 2
+  lockfile: false
+  # read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/charms/istio-ingress-k8s/charmcraft.yaml
+++ b/charms/istio-ingress-k8s/charmcraft.yaml
@@ -69,7 +69,9 @@ config:
         - If set to an empty string, no hostname is set and the listeners accept
           traffic for any hostname.
         - If set to a value, that hostname is used. Must be a `bare` RFC 1123 hostname:
-          i.e. no schema prefix, no port, and no wildcard prefix.
+          i.e. no schema prefix, no port, and no wildcard prefix. If the value is
+          invalid, the charm blocks and the hostname reverts to the default
+          (gateway's local address).
       type: string
     external-traffic-policy-cidrs:
       description: |

--- a/charms/istio-ingress-k8s/charmcraft.yaml
+++ b/charms/istio-ingress-k8s/charmcraft.yaml
@@ -60,6 +60,17 @@ config:
         Hostname can be "precise" which is a domain name without the terminating dot of a network host (e.g. "foo.example.com").
         It's also important to note that domain name prefixed with a single wildcard label (e.g. *.example.com) isn't supported for now.
       type: string
+    listener-hostname:
+      description: |
+        The hostname to set on the K8s Gateway listeners, which controls host-based
+        filtering of incoming traffic.
+        - If unset, defaults to the gateway's local address (external_hostname if set,
+          otherwise the LoadBalancer address), preserving host-based filtering.
+        - If set to an empty string, no hostname is set and the listeners accept
+          traffic for any hostname.
+        - If set to a value, that hostname is used. Must be a `bare` RFC 1123 hostname:
+          i.e. no schema prefix, no port, and no wildcard prefix.
+      type: string
     external-traffic-policy-cidrs:
       description: |
         Comma-separated list of IPs or CIDR blocks from which external traffic is allowed.

--- a/charms/istio-ingress-k8s/charms.just
+++ b/charms/istio-ingress-k8s/charms.just
@@ -1,0 +1,348 @@
+# Centralized justfile for the Canonical Observability charms
+set shell := ["bash", "-uc"]
+
+charm_name := `echo ${PWD##*/} | sed 's/-operator$//'`  # Get the charm name from the folder name
+
+export UV_FROZEN := "true"  # Prevent `uv run` from updating the lockfile
+export PYTHONPATH := ".:./lib:./src"
+
+
+[private]
+@default:
+    just --list
+
+# Print the charm name
+[group("info")]
+@name:
+  echo "{{charm_name}}"
+
+# List all track branches in chronological order (oldest first)
+[group("info")]
+tracks:
+    #!/usr/bin/env python3
+    import subprocess
+
+    def git(*args):
+        r = subprocess.run(["git", *args], capture_output=True, text=True)
+        return r.stdout.strip() if r.returncode == 0 else None
+
+    branches = git("branch", "-r", "--list", "origin/track/*")
+    if not branches:
+        exit(0)
+
+    dated = []
+    for line in branches.splitlines():
+        branch = line.strip().removeprefix("origin/")
+        merge_base = git("merge-base", f"origin/{branch}", "origin/main")
+        if not merge_base:
+            continue
+        first = git("rev-list", "--ancestry-path", f"{merge_base}..origin/{branch}", "--reverse")
+        commit = first.splitlines()[0] if first else merge_base
+        date = git("log", "-1", "--format=%at", commit)
+        dated.append((int(date), branch))
+
+    for _, branch in sorted(dated):
+        print(branch)
+
+# Get the previous track branch relative to the current branch
+[group("info")]
+previous-track:
+    #!/usr/bin/env python3
+    import subprocess
+    import sys
+
+    def git(*args):
+        return subprocess.run(["git", *args], capture_output=True, text=True, check=True).stdout.strip()
+
+    def just(*args):
+        r = subprocess.run(["just", *args], capture_output=True, text=True)
+        if r.returncode != 0:
+            sys.exit(r.returncode)
+        return r.stdout.strip()
+
+    current = git("rev-parse", "--abbrev-ref", "HEAD")
+    tracks = just("tracks").splitlines() if just("tracks") else []
+
+    if not tracks:
+        print("No track branches found", file=sys.stderr)
+        sys.exit(1)
+
+    if current == "main":
+        print(tracks[-1])
+    elif current in tracks:
+        idx = tracks.index(current)
+        if idx > 0:
+            print(tracks[idx - 1])
+    else:
+        print(f"Cannot determine previous track from branch '{current}'", file=sys.stderr)
+        print("Specify ref explicitly: just changelog <ref>", file=sys.stderr)
+        sys.exit(1)
+
+# Update uv.lock dependencies
+[group("maintenance")]
+lock:
+    unset UV_FROZEN; uv lock --upgrade --no-cache
+
+# Scan for security vulnerabilities
+[group("maintenance")]
+scan:
+    @echo "Scanning for security vulnerabilities..."
+    uv audit
+
+# Fetch centralized files from canonical/observability
+[group("maintenance")]
+refresh:
+    #!/usr/bin/env bash
+    which -s gh || { echo "gh not found"; exit 1; }
+    refresh_folder="blueprints/charms"
+    api_path="repos/canonical/observability/contents/$refresh_folder"
+    for file in charms.just .tfdocs.yaml; do
+      echo "Fetching latest '$file' from canonical/observability ..."
+      gh api "$api_path/$file" --jq '.content' | base64 --decode > "$file"
+      echo "✓ $file updated"
+    done
+
+
+# Format the codebase
+[group("dev")]
+format: sync
+    # Fix generic linting issues
+    uv run ruff check --fix-only
+    # Fix import-related issues (including ordering)
+    uv run ruff check --select=I --fix-only
+    # Format the code
+    uv run ruff format
+
+alias fmt := format
+
+# Lint the codebase
+[group("dev")]
+lint: sync
+    # Lint the code
+    uv run ruff check
+    # Run static checks
+    uv run ty check src
+    # Check for misspellings
+    uv run codespell src
+    # Check for dead code (heuristic, so failures are ignored)
+    uv run vulture src --min-confidence=80 || true
+    # Run actionlint on GitHub Actions workflows
+    test -d .github/workflows && uvx --from=actionlint-py actionlint
+    @echo "✓ Linting passed!"
+
+
+# Run all quality checks: formatting, linting and unit tests
+[group("dev")]
+check: sync format lint unit
+    @echo; echo "✓ All checks passed!"
+
+# Sync the virtual environment (.venv)
+[group("dev")]
+sync:
+    uv sync --all-groups --all-extras
+
+# Sync and activate the virtual environment (.venv)
+[group("dev")]
+venv:
+    @echo "Activating virtual environment..."
+    @uv sync --all-groups --all-extras
+    @. .venv/bin/activate; exec "$SHELL" -i
+
+
+# Run unit tests
+[group("test")]
+unit *args: sync
+    uv run coverage run --source=src -m pytest tests/unit {{ args }}
+
+# Run integration tests
+[group("test")]
+integration *args: sync
+    uv run pytest --exitfirst tests/integration {{ args }}
+
+# Pretty print all feature files
+[group("info")]
+features:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    features_dir="tests/integration/features"
+    if [ ! -d "$features_dir" ]; then
+        echo "No features directory found at $features_dir"
+        exit 1
+    fi
+    # Calculate totals first
+    total_features=$(find "$features_dir" -name "*.feature" -type f | wc -l)
+    total_scenarios=$(grep -rh "^[[:space:]]*Scenario:" "$features_dir" 2>/dev/null | wc -l || echo "0")
+    printf "Total: \033[1m%d features\033[0m with \033[1m%d scenarios\033[0m\n" "$total_features" "$total_scenarios"
+    echo ""
+    for feature_file in "$features_dir"/*.feature; do
+        [ -f "$feature_file" ] || continue
+        filename=$(basename "$feature_file")
+        feature_name="${filename%.feature}"
+        # Extract the Feature: line
+        feature_title=$(grep -m1 "^Feature:" "$feature_file" | sed 's/Feature: //')
+        # Extract feature description (lines after Feature: until first Scenario, skipping blank lines)
+        description=$(awk '/^Feature:/{found=1; next} found && /^[[:space:]]*Scenario/{exit} found && /^[[:space:]]*$/{next} found{gsub(/^[[:space:]]+/, ""); print}' "$feature_file" | head -3)
+        # Count scenarios
+        scenario_count=$(grep -c "^[[:space:]]*Scenario:" "$feature_file" || echo "0")
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        printf "\033[1m%s\033[0m (%d scenarios)\n" "$feature_title" "$scenario_count"
+        echo "   $feature_file"
+        echo ""
+        if [ -n "$description" ]; then
+            echo "$description" | while IFS= read -r line; do
+                echo "   $line"
+            done
+            echo ""
+        fi
+        # List scenarios
+        grep "^[[:space:]]*Scenario:" "$feature_file" | sed 's/^[[:space:]]*Scenario:[[:space:]]*//' | while IFS= read -r scenario; do
+            echo "   - $scenario"
+        done
+        echo ""
+    done
+
+
+# Update the Terraform README with auto-generated content
+[group("terraform")]
+terraform-docs:
+    which terraform-docs > /dev/null 2>&1 || { echo "× terraform-docs not found; you can install it via:"; echo "   snap install terraform-docs"; exit 1; }
+    terraform-docs --config .tfdocs.yaml terraform
+    @echo "✓ Terraform docs updated"
+
+# Lint and validate the Terraform module
+[group("terraform")]
+terraform-lint:
+    which terraform > /dev/null 2>&1 || { echo "× terraform not found"; exit 1; }
+    cd terraform && terraform init -backend=false && terraform validate
+    terraform fmt -recursive -check
+    @echo "✓ Terraform lint passed"
+
+
+# Release a .charm file to Charmhub
+[group("release")]
+release charm_file channel:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Upload the charm and get the revision
+    echo "Uploading charm {{ charm_file }}..."
+    upload_output=$(charmcraft upload "{{ charm_file }}" --format=json)
+    charm_revision=$(echo "$upload_output" | jq -r '.revision')
+    echo "✓ Uploaded charm revision: $charm_revision"
+    # Get resources from charmcraft.yaml
+    resource_args=""
+    if [ -f charmcraft.yaml ]; then
+        while IFS= read -r resource_name; do
+            upstream=$(yq -r ".resources.\"$resource_name\".\"upstream-source\" // empty" charmcraft.yaml)
+            if [ -n "$upstream" ]; then
+                echo "Uploading resource '$resource_name' from $upstream..."
+                res_output=$(charmcraft upload-resource "{{ charm_name }}" "$resource_name" --image="docker://$upstream" --format=json)
+                res_revision=$(echo "$res_output" | jq -r '.revision')
+            else
+                echo "Fetching latest revision for resource '$resource_name'..."
+                res_revision=$(charmcraft resource-revisions "{{ charm_name }}" "$resource_name" --format=json | jq -r '.[0].revision')
+            fi
+            echo "✓ Resource '$resource_name' revision: $res_revision"
+            resource_args="$resource_args --resource=$resource_name:$res_revision"
+        done < <(yq -r '.resources | keys | .[]' charmcraft.yaml 2>/dev/null || true)
+    fi
+    # Release the charm
+    echo "Releasing {{ charm_name }} to {{ channel }}..."
+    # shellcheck disable=SC2086
+    charmcraft release "{{ charm_name }}" --revision="$charm_revision" --channel="{{ channel }}" $resource_args
+    echo "✓ Released {{ charm_name }} revision $charm_revision to {{ channel }}"
+
+# Print all commits between two refs (auto-deduces refs when on main or track branches)
+[group("release")]
+[arg("from_ref", help="Branch (or generic ref) to compare from (defaults to previous track)")]
+[arg("to_ref", help="Branch (or generic ref) to compare to (defaults to current branch)")]
+changelog from_ref="" to_ref="":
+    #!/usr/bin/env python3
+    import os
+    import re
+    import subprocess
+    import sys
+
+    def git(*args):
+        return subprocess.run(["git", *args], capture_output=True, text=True, check=True).stdout.strip()
+
+    def just(*args):
+        result = subprocess.run(["just", *args], capture_output=True, text=True)
+        if result.returncode != 0:
+            print(result.stderr, file=sys.stderr, end="")
+            sys.exit(result.returncode)
+        return result.stdout.strip()
+
+    # Get repo path from remote URL
+    remote_url = git("remote", "get-url", "origin")
+    match = re.search(r"github\.com[:/]([^/]+/[^/.]+)", remote_url)
+    repo_path = match.group(1) if match else ""
+
+    # Resolve from_ref (auto-deduce if empty)
+    from_ref = "{{ from_ref }}"
+    if not from_ref:
+        from_ref = just("previous-track")
+        if not from_ref:
+            print("No previous track to compare against", file=sys.stderr)
+            sys.exit(1)
+    try:
+        git("rev-parse", "--verify", from_ref)
+    except subprocess.CalledProcessError:
+        from_ref = f"origin/{from_ref}"
+
+    # Resolve to_ref (default to current branch)
+    to_ref = "{{ to_ref }}" or git("rev-parse", "--abbrev-ref", "HEAD")
+    try:
+        git("rev-parse", "--verify", to_ref)
+    except subprocess.CalledProcessError:
+        to_ref = f"origin/{to_ref}"
+
+    # Get merge-base and commits
+    base = git("merge-base", to_ref, from_ref)
+    log_output = git("log", f"--format=%H\t%s", f"{base}..{to_ref}", "--", os.getcwd())
+
+    # Categorize commits
+    categories = {"breaking": [], "features": [], "fixes": [], "others": []}
+
+    for line in log_output.splitlines():
+        if not line:
+            continue
+        hash, msg = line.split("\t", 1)
+
+        # Skip changelog update commits
+        if msg.startswith("chore(changelog)"):
+            continue
+        short_hash = hash[:7]
+
+        # Format line with links
+        pr_match = re.search(r"\(#(\d+)\)", msg)
+        if pr_match and repo_path:
+            pr_num = pr_match.group(1)
+            formatted = f"- {msg.replace(f'(#{pr_num})', f'([#{pr_num}](https://github.com/{repo_path}/pull/{pr_num}))')}"
+        elif repo_path:
+            formatted = f"- {msg} ([{short_hash}](https://github.com/{repo_path}/commit/{hash}))"
+        else:
+            formatted = f"- {msg} ({short_hash})"
+
+        # Categorize
+        if re.match(r"^[a-z]+(\(.+\))?!:", msg):
+            categories["breaking"].append(formatted)
+        elif re.match(r"^feat(\(.+\))?:", msg):
+            categories["features"].append(formatted)
+        elif re.match(r"^fix(\(.+\))?:", msg):
+            categories["fixes"].append(formatted)
+        else:
+            categories["others"].append(formatted)
+
+    # Print changelog
+    short_base = base[:7]
+    print("# Changelog\n")
+    print(f"Changes on `{to_ref}` since the common ancestor with `{from_ref}` (`{short_base}`).\n")
+    sections = [("Breaking Changes", "breaking"), ("Features", "features"), ("Fixes", "fixes"), ("Others", "others")]
+    for title, key in sections:
+        if categories[key]:
+            print(f"## {title}\n")
+            print("\n".join(categories[key]))
+            print()
+
+
+

--- a/charms/istio-ingress-k8s/justfile
+++ b/charms/istio-ingress-k8s/justfile
@@ -1,0 +1,9 @@
+set allow-duplicate-recipes
+set allow-duplicate-variables
+import? 'charms.just'
+
+[private]
+@default:
+  just --list
+  echo ""
+  echo "For help with a specific recipe, run: just --usage <recipe>"

--- a/charms/istio-ingress-k8s/src/charm.py
+++ b/charms/istio-ingress-k8s/src/charm.py
@@ -623,9 +623,6 @@ class IstioIngressCharm(CharmBase):
             Gateway lightkube resource
         """
         allowed_routes = AllowedRoutes(namespaces={"from": "All"})
-        # Use local gateway address for the K8s Gateway resource hostname,
-        # not the cascaded upstream address
-        hostname = self._local_gateway_address if self._is_valid_hostname(self._local_gateway_address) else None
 
         listeners = []
         for norm_listener in normalized_listeners:
@@ -637,7 +634,6 @@ class IstioIngressCharm(CharmBase):
                 port=norm_listener["port"],
                 protocol=norm_listener["gateway_protocol"],
                 allowedRoutes=allowed_routes,
-                hostname=hostname,
             )
 
             # Add TLS config if this is an HTTPS listener

--- a/charms/istio-ingress-k8s/src/charm.py
+++ b/charms/istio-ingress-k8s/src/charm.py
@@ -1688,19 +1688,21 @@ class IstioIngressCharm(CharmBase):
         - unset (None): default to the local gateway address (previous behavior),
           used only if it is a valid hostname.
         - empty string (""): no hostname, listeners accept traffic for any hostname.
-        - non-empty value: use that hostname (if valid, otherwise None while the charm
-          blocks on the invalid config).
+        - non-empty valid value: use that hostname.
+        - non-empty invalid value: revert to the default (local gateway address) while
+          the charm blocks on the invalid config.
         """
         listener_hostname = cast(Optional[str], self.model.config.get("listener-hostname"))
-        # Unset: preserve the previous behavior of using the local gateway address.
-        if listener_hostname is None:
-            local_address = self._local_gateway_address
-            return local_address if self._is_valid_hostname(local_address) else None
         # Explicit empty string: do not set a hostname (accept all hostnames).
         if listener_hostname == "":
             return None
-        # Explicit value: use it only if valid (the charm blocks otherwise).
-        return listener_hostname if self._is_valid_hostname(listener_hostname) else None
+        # Explicit valid value: use it.
+        if listener_hostname and self._is_valid_hostname(listener_hostname):
+            return listener_hostname
+        # Unset, or explicit but invalid (charm blocks in the latter case): fall back to
+        # the previous behavior of using the local gateway address (if it is valid).
+        local_address = self._local_gateway_address
+        return local_address if self._is_valid_hostname(local_address) else None
 
     @property
     def _ingressed_scheme(self) -> str:

--- a/charms/istio-ingress-k8s/src/charm.py
+++ b/charms/istio-ingress-k8s/src/charm.py
@@ -623,6 +623,7 @@ class IstioIngressCharm(CharmBase):
             Gateway lightkube resource
         """
         allowed_routes = AllowedRoutes(namespaces={"from": "All"})
+        hostname = self._listener_hostname
 
         listeners = []
         for norm_listener in normalized_listeners:
@@ -634,6 +635,7 @@ class IstioIngressCharm(CharmBase):
                 port=norm_listener["port"],
                 protocol=norm_listener["gateway_protocol"],
                 allowedRoutes=allowed_routes,
+                hostname=hostname,
             )
 
             # Add TLS config if this is an HTTPS listener
@@ -1075,6 +1077,7 @@ class IstioIngressCharm(CharmBase):
         self._collect_external_authorization_status(event)
         self._collect_readiness_status(event)
         self._collect_external_hostname_status(event)
+        self._collect_listener_hostname_status(event)
         event.add_status(ActiveStatus(f"Serving at {self._ingress_url}"))
 
     def _collect_leadership_status(self, event: CollectStatusEvent):
@@ -1140,6 +1143,22 @@ class IstioIngressCharm(CharmBase):
         """
         if not self._ingress_url:
             event.add_status(BlockedStatus("Invalid hostname provided, Please ensure this adheres to RFC 1123."))
+
+    def _collect_listener_hostname_status(self, event: CollectStatusEvent):
+        """Block on an invalid, explicitly-set listener-hostname config.
+
+        An unset or empty value is valid (default behavior and "accept all",
+        respectively). A non-empty value must be a valid RFC 1123 hostname.
+
+        (Should be called on the leader unit only.)
+        """
+        listener_hostname = cast(Optional[str], self.model.config.get("listener-hostname"))
+        if listener_hostname and not self._is_valid_hostname(listener_hostname):
+            event.add_status(
+                BlockedStatus(
+                    "Invalid listener-hostname provided, Please ensure this adheres to RFC 1123."
+                )
+            )
 
     def _get_oauth_decisions_address(self) -> Optional[str]:
         """Retrieve the auth configuration decisions_address if it exists.
@@ -1659,6 +1678,29 @@ class IstioIngressCharm(CharmBase):
                 return hostname
             return None
         return self._get_lb_external_address
+
+    @property
+    def _listener_hostname(self) -> Optional[str]:
+        """Return the hostname to set on the K8s Gateway listeners.
+
+        This controls host-based filtering of incoming traffic and is driven by the
+        ``listener-hostname`` config option:
+        - unset (None): default to the local gateway address (previous behavior),
+          used only if it is a valid hostname.
+        - empty string (""): no hostname, listeners accept traffic for any hostname.
+        - non-empty value: use that hostname (if valid, otherwise None while the charm
+          blocks on the invalid config).
+        """
+        listener_hostname = cast(Optional[str], self.model.config.get("listener-hostname"))
+        # Unset: preserve the previous behavior of using the local gateway address.
+        if listener_hostname is None:
+            local_address = self._local_gateway_address
+            return local_address if self._is_valid_hostname(local_address) else None
+        # Explicit empty string: do not set a hostname (accept all hostnames).
+        if listener_hostname == "":
+            return None
+        # Explicit value: use it only if valid (the charm blocks otherwise).
+        return listener_hostname if self._is_valid_hostname(listener_hostname) else None
 
     @property
     def _ingressed_scheme(self) -> str:

--- a/charms/istio-ingress-k8s/terraform/README.md
+++ b/charms/istio-ingress-k8s/terraform/README.md
@@ -2,14 +2,14 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 1.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_juju"></a> [juju](#provider\_juju) | >= 1.0 |
 
 ## Modules
@@ -19,7 +19,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name to give the deployed application | `string` | `"istio-ingress-k8s"` | no |
 | <a name="input_channel"></a> [channel](#input\_channel) | Channel that the charm is deployed from | `string` | n/a | yes |
 | <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
@@ -32,7 +32,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
 | <a name="output_provides"></a> [provides](#output\_provides) | n/a |
 | <a name="output_requires"></a> [requires](#output\_requires) | n/a |

--- a/charms/istio-ingress-k8s/tests/integration/test_charm_ipa.py
+++ b/charms/istio-ingress-k8s/tests/integration/test_charm_ipa.py
@@ -3,7 +3,6 @@
 
 import logging
 from pathlib import Path
-from typing import Optional
 
 import pytest
 import requests
@@ -134,18 +133,9 @@ def test_auth_policy_validity(juju: Juju):
         )
 
 
-@pytest.mark.parametrize(
-    "external_hostname, expected_hostname",
-    [
-        ("foo.bar", "foo.bar"),  # Initial valid hostname
-        ("bar.foo", "bar.foo"),  # Change to a new valid hostname
-        ("", None),  # Remove hostname
-    ],
-)
 @pytest.mark.dependency(name="test_route_validity", depends=["test_relate"])
-def test_route_validity(juju: Juju, external_hostname: str, expected_hostname: Optional[str]):
+def test_route_validity(juju: Juju):
     """Test that routes to apps related on the ingress and ingress-unauthenticated endpoints work as expected."""
-    juju.config(APP_NAME, {"external_hostname": external_hostname})
     juju.wait(
         lambda s: all_active(s, APP_NAME, IPA_TESTER, IPA_TESTER_UNAUTHENTICATED),
         timeout=1000,
@@ -159,6 +149,10 @@ def test_route_validity(juju: Juju, external_hostname: str, expected_hostname: O
     assert listener_condition["attachedRoutes"] == 2
     assert listener_condition["conditions"][0]["message"] == "No errors found"
     assert listener_condition["conditions"][0]["reason"] == "Accepted"
+
+    # Assert that no hostname is set on the listener (listeners accept traffic for any hostname)
+    assert "hostname" not in listener_spec
+
     for ipa_tester in [IPA_TESTER, IPA_TESTER_UNAUTHENTICATED]:
         tester_url = f"http://{istio_ingress_address}/{model}-{ipa_tester}"
         # the route name will follow the format {ingressed_app_name}-{httproute or grpcroute}-{listener_name}-{ingress_app_name}
@@ -168,14 +162,7 @@ def test_route_validity(juju: Juju, external_hostname: str, expected_hostname: O
         assert route_condition["conditions"][0]["message"] == "Route was valid"
         assert route_condition["conditions"][0]["reason"] == "Accepted"
         assert route_condition["controllerName"] == "istio.io/gateway-controller"
-        if not expected_hostname:
-            assert "hostname" not in listener_spec
-            assert send_http_request(tester_url)
-        else:
-            assert listener_spec["hostname"] == expected_hostname
-            assert send_http_request(tester_url, {"Host": expected_hostname})
-            assert not send_http_request(tester_url)
-            assert not send_http_request(tester_url, {"Host": "random.hostname"})
+        assert send_http_request(tester_url)
 
 
 @pytest.fixture(scope="module")

--- a/charms/istio-ingress-k8s/tests/integration/test_charm_ipa.py
+++ b/charms/istio-ingress-k8s/tests/integration/test_charm_ipa.py
@@ -3,6 +3,7 @@
 
 import logging
 from pathlib import Path
+from typing import Optional
 
 import pytest
 import requests
@@ -133,9 +134,28 @@ def test_auth_policy_validity(juju: Juju):
         )
 
 
+@pytest.mark.parametrize(
+    "config, reset, expected_hostname",
+    [
+        # listener-hostname unset: defaults to the local gateway address (external_hostname
+        # here), preserving the previous host-based filtering behavior.
+        ({"external_hostname": "foo.bar"}, ["listener-hostname"], "foo.bar"),
+        # listener-hostname set to a value: overrides the local gateway address.
+        ({"external_hostname": "foo.bar", "listener-hostname": "bar.foo"}, [], "bar.foo"),
+        # listener-hostname set to an empty string: no hostname, accept traffic for any host.
+        # Also reset external_hostname so this leaves a clean slate for subsequent tests.
+        ({"listener-hostname": ""}, ["external_hostname"], None),
+    ],
+)
 @pytest.mark.dependency(name="test_route_validity", depends=["test_relate"])
-def test_route_validity(juju: Juju):
+def test_route_validity(
+    juju: Juju,
+    config: dict,
+    reset: list,
+    expected_hostname: Optional[str],
+):
     """Test that routes to apps related on the ingress and ingress-unauthenticated endpoints work as expected."""
+    juju.config(APP_NAME, config, reset=reset)
     juju.wait(
         lambda s: all_active(s, APP_NAME, IPA_TESTER, IPA_TESTER_UNAUTHENTICATED),
         timeout=1000,
@@ -150,9 +170,6 @@ def test_route_validity(juju: Juju):
     assert listener_condition["conditions"][0]["message"] == "No errors found"
     assert listener_condition["conditions"][0]["reason"] == "Accepted"
 
-    # Assert that no hostname is set on the listener (listeners accept traffic for any hostname)
-    assert "hostname" not in listener_spec
-
     for ipa_tester in [IPA_TESTER, IPA_TESTER_UNAUTHENTICATED]:
         tester_url = f"http://{istio_ingress_address}/{model}-{ipa_tester}"
         # the route name will follow the format {ingressed_app_name}-{httproute or grpcroute}-{listener_name}-{ingress_app_name}
@@ -162,7 +179,17 @@ def test_route_validity(juju: Juju):
         assert route_condition["conditions"][0]["message"] == "Route was valid"
         assert route_condition["conditions"][0]["reason"] == "Accepted"
         assert route_condition["controllerName"] == "istio.io/gateway-controller"
-        assert send_http_request(tester_url)
+        if not expected_hostname:
+            # No hostname set: listeners accept traffic for any hostname.
+            assert "hostname" not in listener_spec
+            assert send_http_request(tester_url)
+        else:
+            # Hostname set: only traffic for the matching host is accepted.
+            assert listener_spec["hostname"] == expected_hostname
+            assert send_http_request(tester_url, {"Host": expected_hostname})
+            assert not send_http_request(tester_url)
+            assert not send_http_request(tester_url, {"Host": "random.hostname"})
+
 
 
 @pytest.fixture(scope="module")

--- a/charms/istio-ingress-k8s/tests/unit/test_gateway.py
+++ b/charms/istio-ingress-k8s/tests/unit/test_gateway.py
@@ -64,36 +64,9 @@ def test_construct_gateway(istio_ingress_charm, istio_ingress_context):
         assert gateway.spec["listeners"][0].get("hostname", None) is None
 
 
-@patch("charm.IstioIngressCharm._get_lb_external_address", new_callable=PropertyMock)
-def test_construct_gateway_with_loadbalancer_address(
-    mock_get_lb_external_address, istio_ingress_charm, istio_ingress_context
-):
-    """Assert that when a LoadBalancer address is available, the Gateway definition uses that hostname."""
-    hostname = "example.com"
-    mock_get_lb_external_address.return_value = hostname
-    with istio_ingress_context(
-        istio_ingress_context.on.update_status(),
-        state=scenario.State(),
-    ) as manager:
-        charm = manager.charm
-        normalized_listeners = create_test_listeners()
-        gateway = charm._construct_gateway(normalized_listeners)
 
-        # Assert that the Gateway has an http listener with the correct configurations
-        _validate_gateway_listener(gateway, "http-80", hostname, tls_secret_name=None)
-
-
-@patch(
-    "charm.IstioIngressCharm._get_lb_external_address",
-    new_callable=PropertyMock,
-    return_value=None,
-)
-def test_construct_gateway_with_tls(
-    mock_get_lb_external_address, istio_ingress_charm, istio_ingress_context
-):
+def test_construct_gateway_with_tls(istio_ingress_charm, istio_ingress_context):
     """Assert that when TLS is configured, the Gateway definition is constructed using TLS as expected."""
-    hostname = "example.com"
-    mock_get_lb_external_address.return_value = hostname
     tls_secret_name = "tls-secret"
     with istio_ingress_context(
         istio_ingress_context.on.update_status(),
@@ -108,8 +81,12 @@ def test_construct_gateway_with_tls(
         gateway = charm._construct_gateway(normalized_listeners)
 
         # Assert that the Gateway has http and https listeners with the correct configurations.
-        _validate_gateway_listener(gateway, "http-80", hostname, tls_secret_name=None)
-        _validate_gateway_listener(gateway, "https-443", hostname, tls_secret_name=tls_secret_name)
+        _validate_gateway_listener(gateway, "http-80", tls_secret_name=None)
+        _validate_gateway_listener(gateway, "https-443", tls_secret_name=tls_secret_name)
+
+        # Assert that no hostname is set on any listener
+        for listener in gateway.spec["listeners"]:
+            assert listener.get("hostname", None) is None
 
 
 def test_sync_gateway_resources_without_tls(istio_ingress_charm, istio_ingress_context):
@@ -143,7 +120,7 @@ def test_sync_gateway_resources_without_tls(istio_ingress_charm, istio_ingress_c
     return_value=None,
 )
 def test_sync_gateway_resources_with_tls_without_loadbalancer_address(
-    istio_ingress_charm, istio_ingress_context
+    mock_get_lb_external_address, istio_ingress_charm, istio_ingress_context
 ):
     """Test that when we have a full TLS relation but no LoadBalancer address, the Gateway has only an http listener."""
     mock_krm = MagicMock()
@@ -169,15 +146,12 @@ def test_sync_gateway_resources_with_tls_without_loadbalancer_address(
             _get_listener_given_name(gateway, "https-443")
 
 
-@patch("charm.IstioIngressCharm._get_lb_external_address", new_callable=PropertyMock)
 def test_sync_gateway_resources_with_tls_with_loadbalancer_address(
-    mock_get_lb_external_address, istio_ingress_charm, istio_ingress_context
+    istio_ingress_charm, istio_ingress_context
 ):
     """Test that when we have a TLS relation and a LoadBalancer address, the Gateway has http and https listeners."""
     mock_krm = MagicMock()
     mock_krm_factory = MagicMock(return_value=mock_krm)
-    hostname = "example.com"
-    mock_get_lb_external_address.return_value = hostname
     certificate_info = generate_certificates_relation()
 
     with istio_ingress_context(
@@ -202,10 +176,14 @@ def test_sync_gateway_resources_with_tls_with_loadbalancer_address(
 
         # Assert that the Gateway was created and has http and https listeners with the correct configurations.
         gateway = charm._get_gateway_resource_manager().reconcile.call_args[0][0][1]
-        _validate_gateway_listener(gateway, "http-80", hostname, tls_secret_name=None)
+        _validate_gateway_listener(gateway, "http-80", tls_secret_name=None)
         _validate_gateway_listener(
-            gateway, "https-443", hostname, tls_secret_name=charm._certificate_secret_name
+            gateway, "https-443", tls_secret_name=charm._certificate_secret_name
         )
+
+        # Assert that no hostname is set on any listener
+        for listener in gateway.spec["listeners"]:
+            assert listener.get("hostname", None) is None
 
 
 def test_sync_gateway_resources_with_tls_with_external_hostname_config(
@@ -241,10 +219,14 @@ def test_sync_gateway_resources_with_tls_with_external_hostname_config(
 
         # Assert that the Gateway was created and has http and https listeners with the correct configurations.
         gateway = charm._get_gateway_resource_manager().reconcile.call_args[0][0][1]
-        _validate_gateway_listener(gateway, "http-80", hostname, tls_secret_name=None)
+        _validate_gateway_listener(gateway, "http-80", tls_secret_name=None)
         _validate_gateway_listener(
-            gateway, "https-443", hostname, tls_secret_name=charm._certificate_secret_name
+            gateway, "https-443", tls_secret_name=charm._certificate_secret_name
         )
+
+        # Assert that no hostname is set on any listener
+        for listener in gateway.spec["listeners"]:
+            assert listener.get("hostname", None) is None
 
 
 @pytest.mark.parametrize(
@@ -370,13 +352,10 @@ def generate_certificates_relation(subject="example.com"):
 def _validate_gateway_listener(
     gateway,
     listener_name: str,
-    hostname: Optional[str] = None,
     tls_secret_name: Optional[str] = None,
 ):
     """Validates the Gateway object has the listener with expected configuration."""
     listener = _get_listener_given_name(gateway, listener_name)
-    if hostname:
-        assert listener.get("hostname", None) == hostname
     if tls_secret_name:
         assert len(listener["tls"]["certificateRefs"]) == 1
         assert listener["tls"]["certificateRefs"][0]["name"] == tls_secret_name

--- a/charms/istio-ingress-k8s/tests/unit/test_gateway.py
+++ b/charms/istio-ingress-k8s/tests/unit/test_gateway.py
@@ -64,7 +64,6 @@ def test_construct_gateway(istio_ingress_charm, istio_ingress_context):
         assert gateway.spec["listeners"][0].get("hostname", None) is None
 
 
-
 def test_construct_gateway_with_tls(istio_ingress_charm, istio_ingress_context):
     """Assert that when TLS is configured, the Gateway definition is constructed using TLS as expected."""
     tls_secret_name = "tls-secret"

--- a/charms/istio-ingress-k8s/tests/unit/test_gateway.py
+++ b/charms/istio-ingress-k8s/tests/unit/test_gateway.py
@@ -15,7 +15,7 @@ from charms.tls_certificates_interface.v3.tls_certificates import (
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.autoscaling_v2 import HorizontalPodAutoscaler
 from lightkube.resources.core_v1 import Secret
-from ops import ActiveStatus
+from ops import ActiveStatus, BlockedStatus
 
 from charm import IstioIngressCharm
 from utils import GatewayListener
@@ -88,6 +88,87 @@ def test_construct_gateway_with_tls(istio_ingress_charm, istio_ingress_context):
             assert listener.get("hostname", None) is None
 
 
+@patch("charm.IstioIngressCharm._get_lb_external_address", new_callable=PropertyMock)
+def test_construct_gateway_default_uses_local_address(
+    mock_get_lb_external_address, istio_ingress_charm, istio_ingress_context
+):
+    """When listener-hostname is unset, the local gateway address is used (previous behavior)."""
+    hostname = "example.com"
+    mock_get_lb_external_address.return_value = hostname
+    with istio_ingress_context(
+        istio_ingress_context.on.update_status(),
+        state=scenario.State(),
+    ) as manager:
+        charm = manager.charm
+        gateway = charm._construct_gateway(create_test_listeners())
+
+        _validate_gateway_listener(gateway, "http-80", hostname, tls_secret_name=None)
+
+
+def test_construct_gateway_with_empty_listener_hostname(
+    istio_ingress_charm, istio_ingress_context
+):
+    """When listener-hostname is an empty string, no hostname is set (accept all)."""
+    with istio_ingress_context(
+        istio_ingress_context.on.update_status(),
+        state=scenario.State(config={"listener-hostname": ""}),
+    ) as manager:
+        charm = manager.charm
+        gateway = charm._construct_gateway(create_test_listeners())
+
+        assert gateway.spec["listeners"][0].get("hostname", None) is None
+
+
+@patch("charm.IstioIngressCharm._get_lb_external_address", new_callable=PropertyMock)
+def test_construct_gateway_with_explicit_listener_hostname(
+    mock_get_lb_external_address, istio_ingress_charm, istio_ingress_context
+):
+    """When listener-hostname is set, that value overrides the local gateway address."""
+    mock_get_lb_external_address.return_value = "lb.example.com"
+    with istio_ingress_context(
+        istio_ingress_context.on.update_status(),
+        state=scenario.State(config={"listener-hostname": "custom.example.com"}),
+    ) as manager:
+        charm = manager.charm
+        gateway = charm._construct_gateway(create_test_listeners())
+
+        _validate_gateway_listener(
+            gateway, "http-80", "custom.example.com", tls_secret_name=None
+        )
+
+
+def test_invalid_listener_hostname_blocks(istio_ingress_charm, istio_ingress_context):
+    """An invalid, explicitly-set listener-hostname makes the charm block."""
+    with istio_ingress_context(
+        istio_ingress_context.on.update_status(),
+        state=scenario.State(leader=True, config={"listener-hostname": "not a valid host"}),
+    ) as manager:
+        charm = manager.charm
+        # No hostname is applied when the configured value is invalid
+        gateway = charm._construct_gateway(create_test_listeners())
+        assert gateway.spec["listeners"][0].get("hostname", None) is None
+
+        # And the charm surfaces a blocked status about the invalid config
+        event = MagicMock()
+        charm._collect_listener_hostname_status(event)
+        event.add_status.assert_called_once()
+        status = event.add_status.call_args[0][0]
+        assert isinstance(status, BlockedStatus)
+        assert "listener-hostname" in status.message
+
+
+def test_valid_listener_hostname_does_not_block(istio_ingress_charm, istio_ingress_context):
+    """A valid or empty/unset listener-hostname does not add a blocked status."""
+    for config in ({}, {"listener-hostname": ""}, {"listener-hostname": "valid.example.com"}):
+        with istio_ingress_context(
+            istio_ingress_context.on.update_status(),
+            state=scenario.State(leader=True, config=config),
+        ) as manager:
+            event = MagicMock()
+            manager.charm._collect_listener_hostname_status(event)
+            event.add_status.assert_not_called()
+
+
 def test_sync_gateway_resources_without_tls(istio_ingress_charm, istio_ingress_context):
     """Test that when we have no TLS relation, the Gateway has only an http listener."""
     mock_krm = MagicMock()
@@ -145,12 +226,15 @@ def test_sync_gateway_resources_with_tls_without_loadbalancer_address(
             _get_listener_given_name(gateway, "https-443")
 
 
+@patch("charm.IstioIngressCharm._get_lb_external_address", new_callable=PropertyMock)
 def test_sync_gateway_resources_with_tls_with_loadbalancer_address(
-    istio_ingress_charm, istio_ingress_context
+    mock_get_lb_external_address, istio_ingress_charm, istio_ingress_context
 ):
     """Test that when we have a TLS relation and a LoadBalancer address, the Gateway has http and https listeners."""
     mock_krm = MagicMock()
     mock_krm_factory = MagicMock(return_value=mock_krm)
+    hostname = "example.com"
+    mock_get_lb_external_address.return_value = hostname
     certificate_info = generate_certificates_relation()
 
     with istio_ingress_context(
@@ -175,14 +259,14 @@ def test_sync_gateway_resources_with_tls_with_loadbalancer_address(
 
         # Assert that the Gateway was created and has http and https listeners with the correct configurations.
         gateway = charm._get_gateway_resource_manager().reconcile.call_args[0][0][1]
-        _validate_gateway_listener(gateway, "http-80", tls_secret_name=None)
+        _validate_gateway_listener(gateway, "http-80", hostname, tls_secret_name=None)
         _validate_gateway_listener(
-            gateway, "https-443", tls_secret_name=charm._certificate_secret_name
+            gateway, "https-443", hostname, tls_secret_name=charm._certificate_secret_name
         )
 
-        # Assert that no hostname is set on any listener
+        # Assert that, by default, the local gateway address is used as the listener hostname
         for listener in gateway.spec["listeners"]:
-            assert listener.get("hostname", None) is None
+            assert listener.get("hostname", None) == hostname
 
 
 def test_sync_gateway_resources_with_tls_with_external_hostname_config(
@@ -218,14 +302,14 @@ def test_sync_gateway_resources_with_tls_with_external_hostname_config(
 
         # Assert that the Gateway was created and has http and https listeners with the correct configurations.
         gateway = charm._get_gateway_resource_manager().reconcile.call_args[0][0][1]
-        _validate_gateway_listener(gateway, "http-80", tls_secret_name=None)
+        _validate_gateway_listener(gateway, "http-80", hostname, tls_secret_name=None)
         _validate_gateway_listener(
-            gateway, "https-443", tls_secret_name=charm._certificate_secret_name
+            gateway, "https-443", hostname, tls_secret_name=charm._certificate_secret_name
         )
 
-        # Assert that no hostname is set on any listener
+        # Assert that, by default, the local gateway address is used as the listener hostname
         for listener in gateway.spec["listeners"]:
-            assert listener.get("hostname", None) is None
+            assert listener.get("hostname", None) == hostname
 
 
 @pytest.mark.parametrize(
@@ -351,10 +435,15 @@ def generate_certificates_relation(subject="example.com"):
 def _validate_gateway_listener(
     gateway,
     listener_name: str,
+    hostname: Optional[str] = None,
     tls_secret_name: Optional[str] = None,
 ):
     """Validates the Gateway object has the listener with expected configuration."""
     listener = _get_listener_given_name(gateway, listener_name)
+    if hostname:
+        assert listener.get("hostname", None) == hostname
+    else:
+        assert listener.get("hostname", None) is None
     if tls_secret_name:
         assert len(listener["tls"]["certificateRefs"]) == 1
         assert listener["tls"]["certificateRefs"][0]["name"] == tls_secret_name

--- a/charms/istio-ingress-k8s/tests/unit/test_gateway.py
+++ b/charms/istio-ingress-k8s/tests/unit/test_gateway.py
@@ -83,10 +83,6 @@ def test_construct_gateway_with_tls(istio_ingress_charm, istio_ingress_context):
         _validate_gateway_listener(gateway, "http-80", tls_secret_name=None)
         _validate_gateway_listener(gateway, "https-443", tls_secret_name=tls_secret_name)
 
-        # Assert that no hostname is set on any listener
-        for listener in gateway.spec["listeners"]:
-            assert listener.get("hostname", None) is None
-
 
 @patch("charm.IstioIngressCharm._get_lb_external_address", new_callable=PropertyMock)
 def test_construct_gateway_default_uses_local_address(
@@ -137,16 +133,24 @@ def test_construct_gateway_with_explicit_listener_hostname(
         )
 
 
-def test_invalid_listener_hostname_blocks(istio_ingress_charm, istio_ingress_context):
-    """An invalid, explicitly-set listener-hostname makes the charm block."""
+@patch("charm.IstioIngressCharm._get_lb_external_address", new_callable=PropertyMock)
+def test_invalid_listener_hostname_blocks(
+    mock_get_lb_external_address, istio_ingress_charm, istio_ingress_context
+):
+    """An invalid, explicitly-set listener-hostname makes the charm block.
+
+    The listener hostname reverts to the default (local gateway address) rather than
+    being left unset.
+    """
+    mock_get_lb_external_address.return_value = "lb.example.com"
     with istio_ingress_context(
         istio_ingress_context.on.update_status(),
         state=scenario.State(leader=True, config={"listener-hostname": "not a valid host"}),
     ) as manager:
         charm = manager.charm
-        # No hostname is applied when the configured value is invalid
+        # The invalid value is ignored and the default local gateway address is used
         gateway = charm._construct_gateway(create_test_listeners())
-        assert gateway.spec["listeners"][0].get("hostname", None) is None
+        assert gateway.spec["listeners"][0].get("hostname", None) == "lb.example.com"
 
         # And the charm surfaces a blocked status about the invalid config
         event = MagicMock()

--- a/charms/istio-ingress-k8s/tests/unit/test_ingress_config.py
+++ b/charms/istio-ingress-k8s/tests/unit/test_ingress_config.py
@@ -44,6 +44,8 @@ def test_config_changed(harness: Harness[MockRequirerCharm]):
     harness.add_network("10.0.0.10")
     relation_id = harness.add_relation("ingress", "istio-ingress")
     harness.add_relation_unit(relation_id, "istio-ingress/0")
+    relation = harness.model.get_relation("ingress", relation_id)
+    harness.charm.on["ingress"].relation_changed.emit(relation)
 
     req_app_data = harness.get_relation_data(relation_id, "test-requirer")
     req_unit_data = harness.get_relation_data(relation_id, "test-requirer/0")

--- a/charms/istio-ingress-k8s/tests/unit/test_upstream_ingress.py
+++ b/charms/istio-ingress-k8s/tests/unit/test_upstream_ingress.py
@@ -62,6 +62,3 @@ def test_ingress_url_with_scheme_uses_upstream(harness):
         IngressPerAppRequirer, "url", new_callable=PropertyMock, return_value="https://upstream.example.com/model-app/"
     ):
         assert charm._ingress_url_with_scheme() == "https://upstream.example.com/model-app"
-
-
-

--- a/charms/istio-ingress-k8s/tests/unit/test_upstream_ingress.py
+++ b/charms/istio-ingress-k8s/tests/unit/test_upstream_ingress.py
@@ -64,17 +64,4 @@ def test_ingress_url_with_scheme_uses_upstream(harness):
         assert charm._ingress_url_with_scheme() == "https://upstream.example.com/model-app"
 
 
-def test_construct_gateway_uses_local_address_not_upstream(harness):
-    """The Gateway K8s resource hostname should use the local address, not the cascaded upstream."""
-    harness.update_config({"external_hostname": "local.example.com"})
-    harness.begin()
-    charm = harness.charm
 
-    with patch.object(
-        charm.upstream_ingress, "is_ready", return_value=True
-    ), patch.object(
-        IngressPerAppRequirer, "url", new_callable=PropertyMock, return_value="https://upstream.example.com/model-app/"
-    ):
-        listeners = [{"port": 80, "gateway_protocol": "HTTP", "tls_secret_name": None, "source_app": "test"}]
-        gateway = charm._construct_gateway(listeners)
-        assert gateway.spec["listeners"][0]["hostname"] == "local.example.com"

--- a/charms/istio-ingress-k8s/tests/unit/test_upstream_ingress.py
+++ b/charms/istio-ingress-k8s/tests/unit/test_upstream_ingress.py
@@ -62,3 +62,20 @@ def test_ingress_url_with_scheme_uses_upstream(harness):
         IngressPerAppRequirer, "url", new_callable=PropertyMock, return_value="https://upstream.example.com/model-app/"
     ):
         assert charm._ingress_url_with_scheme() == "https://upstream.example.com/model-app"
+
+
+def test_construct_gateway_uses_local_address_not_upstream(harness):
+    """By default the Gateway listener hostname uses the local address, not the cascaded upstream."""
+    harness.update_config({"external_hostname": "local.example.com"})
+    harness.begin()
+    charm = harness.charm
+
+    with patch.object(
+        charm.upstream_ingress, "is_ready", return_value=True
+    ), patch.object(
+        IngressPerAppRequirer, "url", new_callable=PropertyMock, return_value="https://upstream.example.com/model-app/"
+    ):
+        listeners = [{"port": 80, "gateway_protocol": "HTTP", "tls_secret_name": None, "source_app": "test"}]
+        gateway = charm._construct_gateway(listeners)
+        assert gateway.spec["listeners"][0]["hostname"] == "local.example.com"
+


### PR DESCRIPTION
Fixes #102

~~We stop setting hostname in the Listener entirely.~~

We are now using a config value to control this. If the config value is unset, we use default hostname as before. If it is set, then we use the set value (where "" means any host).