### PR TITLE
fix(ci): point to the right release-please config

### DIFF
--- a/.github/workflows/canonical-service-mesh-release.yaml
+++ b/.github/workflows/canonical-service-mesh-release.yaml
@@ -52,8 +52,8 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          config-file: canonical_service_mesh/release-please-config.json
-          manifest-file: canonical_service_mesh/.release-please-manifest.json
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
 
   publish:
     needs: release-please


### PR DESCRIPTION
The package workflow was pointing to the wrong release please config path. 

Why are we changing the workflow and not putting release please config in the canonical-service-mesh folder? the release please config is package agnostic, we can use the config to manage a different package in the future, so it stays at the root
