### PR TITLE
feat: adds a dummy setup for chaining haproxy and istio-ingress-k8s

### DIFF
--- a/projects/haproxy/README.md
+++ b/projects/haproxy/README.md
@@ -1,0 +1,73 @@
+# HAProxy → ingress-configurator → Istio ingress
+
+A small experiment: put the machine **HAProxy** charm in front of the k8s **Istio ingress
+gateway**, wiring them together through the **ingress-configurator** charm over the
+`haproxy-route-tcp` relation. HAProxy acts as an L4 (TCP) entry point; Istio does the real L7 work.
+
+## Topology
+
+```
+client ──tcp/tls──> haproxy (machine, LXD) ──tcp──> istio-ingress LB :80/:443 ──> istio-envoy ──> app
+                        ▲
+        ingress-configurator (k8s) configures haproxy over `haproxy-route-tcp`
+        and points its TCP backend at the istio-ingress LoadBalancer IP.
+```
+
+- `istio-k8s`, `istio-ingress-k8s`, `ingress-configurator`, BookInfo → **k8s** model (`mcrk8s:mesh`).
+- `haproxy` → **machine** model (`lxd:proxy`); it's a machine charm, so it needs an LXD controller.
+- The `haproxy-route-tcp` relation is a **cross-model / cross-controller** relation (`juju offer` + `consume`).
+- "Pointing at Istio" is **config**, not a relation: ingress-configurator's `tcp-backend-addresses`
+  + `tcp-port-mapping` are set to the istio-ingress LB IP and ports (integrator / config-driven mode).
+
+## What we validated
+
+**1. Plain TCP passthrough (HTTP).** haproxy forwards raw TCP on `:80` to the istio LB `:80`.
+All routing (`/mesh-bookinfo-productpage-k8s`) is done by istio-envoy. `curl` through haproxy → **200**.
+
+**2. TLS passthrough (HTTPS, SNI-routed).** With self-signed-certificates on istio-ingress,
+the gateway serves HTTPS `:443` for `bookinfo.test`. ingress-configurator is set to
+`tcp-tls-terminate=false` + `tcp-hostname=bookinfo.test`, which renders in haproxy as:
+
+```
+frontend haproxy_route_tcp_443
+    mode tcp
+    tcp-request content accept if { req_ssl_hello_type 1 }   # wait for TLS ClientHello
+    acl ... req.ssl_sni -i bookinfo.test                     # match SNI (cleartext)
+    use_backend ... 192.168.0.132:443                        # forward ciphertext, no decrypt
+```
+
+`curl https://bookinfo.test/... ` through haproxy → **200**, and the served cert is
+`CN=bookinfo.test` issued by the SSC CA — i.e. **istio's** cert. HAProxy never terminates TLS;
+it only reads the SNI to route. Istio holds the key and does everything else.
+
+## Key takeaways
+
+- In these modes HAProxy is a **dumb L4 box**: TCP forward, optionally matching the ClientHello SNI.
+  No decryption, no HTTP parsing, no host/path routing — Istio owns all of that.
+- The hostname lives in **two** places that must match: `istio-ingress-k8s external_hostname`
+  (cert SAN + L7 routing) and `ingress-configurator tcp-hostname` (haproxy's SNI match, pushed via
+  the relation). It is **not** HAProxy's own config.
+- SSC on the **haproxy** side is unused for passthrough (the client trusts istio's cert); it would
+  only matter with `tcp-tls-terminate=true` (haproxy terminates and re-encrypts).
+
+## Gotchas
+
+- Use **`haproxy 2.8/candidate`**. `2.8/stable` ships `haproxy_route_tcp` v1.3 (requires `port`,
+  no `port_mapping`) and rejects the requirer databag; `2.8/edge` is arm64-only.
+- `juju info haproxy` shows stale classic-charm relation metadata — trust the charm source.
+- For a plain-HTTP pass haproxy needs `external-hostname` set and TCP TLS disabled, or it blocks
+  on "TLS not ready".
+
+## Reproduce
+
+Prereqs: `lxd` and `mcrk8s` (MetalLB-enabled) controllers bootstrapped; `just` + `jq` installed.
+
+```bash
+just -f setup.just all               # models, deploy, relate, configure, verify (HTTP passthrough)
+just -f setup.just bookinfo          # optional real backend behind istio
+just -f setup.just verify-bookinfo   # HTTP 200 through haproxy
+just -f setup.just tls-passthrough   # SSC + SNI passthrough on :443, then verify (HTTPS 200)
+just -f setup.just clean             # tear down
+```
+
+See `setup.just` for the individual recipes and tunables (controller/model names, channels, ports).

--- a/projects/haproxy/setup.just
+++ b/projects/haproxy/setup.just
@@ -1,0 +1,182 @@
+# Reproduce: haproxy --(haproxy-route-tcp)--> ingress-configurator --> istio-ingress-k8s
+#
+# Prerequisites (assumed already done):
+#   - An LXD (machine) controller is bootstrapped         -> `juju bootstrap localhost lxd`
+#   - A MicroK8s (k8s) controller is bootstrapped w/ MetalLB enabled
+#   - `just` and `jq` are installed
+#
+# Topology:
+#   client -> haproxy (machine model, LXD) :80  --tcp-->  istio-ingress LB IP:80  -> istio-envoy
+#   haproxy provides `haproxy-route-tcp`; ingress-configurator (k8s model) consumes it via CMR
+#   and is configured (integrator/config-driven mode) to point its TCP backend at istio-ingress.
+
+# --- configuration -----------------------------------------------------------
+
+k8s_ctrl   := "mcrk8s"          # name of the k8s controller
+lxd_ctrl   := "lxd"             # name of the lxd controller
+mesh       := "mesh"            # k8s model (istio + configurator)
+proxy      := "proxy"           # machine model (haproxy)
+
+istio_channel  := "dev/edge"
+ic_channel     := "latest/edge"
+# NOTE: haproxy channel must ship haproxy_route_tcp >= v1.6 (port_mapping support).
+# 2.8/stable (v1.3) is too old and rejects the databag; 2.8/edge is arm64-only.
+haproxy_channel := "2.8/candidate"
+
+frontend_port := "80"           # port exposed on haproxy
+backend_port  := "80"           # istio-ingress gateway HTTP port
+
+_mesh  := k8s_ctrl + ":" + mesh
+_proxy := lxd_ctrl + ":" + proxy
+
+# --- meta --------------------------------------------------------------------
+
+default:
+    @just --list
+
+# Full run, end to end.
+all: models deploy relate configure verify
+
+# --- setup -------------------------------------------------------------------
+
+models:
+    juju add-model -c {{k8s_ctrl}} {{mesh}} || true
+    juju add-model -c {{lxd_ctrl}} {{proxy}} || true
+
+deploy: deploy-istio deploy-configurator deploy-haproxy
+
+# Optional: a real backend behind istio-ingress so the chain returns 200 (not just 404).
+# Deploys BookInfo (productpage + details) and routes it through istio-ingress `ingress`.
+bookinfo:
+    juju deploy -m {{_mesh}} bookinfo-productpage-k8s --channel latest/stable
+    juju deploy -m {{_mesh}} bookinfo-details-k8s     --channel latest/stable
+    juju integrate -m {{_mesh}} bookinfo-productpage-k8s:ingress istio-ingress-k8s:ingress
+    juju integrate -m {{_mesh}} bookinfo-productpage-k8s:details bookinfo-details-k8s:details
+    juju wait-for application -m {{_mesh}} bookinfo-productpage-k8s --query='status=="active"' --timeout=15m
+
+# Curl the BookInfo productpage THROUGH haproxy (expects HTTP 200).
+verify-bookinfo:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    HAP=$(just _haproxy-addr)
+    PATH_=$(juju exec -m {{_mesh}} --unit bookinfo-productpage-k8s/0 -- bash -c \
+      'for r in $(relation-ids ingress); do relation-get -r $r --app - istio-ingress-k8s; done' \
+      | sed -n 's/.*"url": "[^/]*\/\/[^/]*\(\/[^"]*\)".*/\1/p')
+    echo "productpage path: ${PATH_}"
+    echo "== through haproxy (${HAP}${PATH_}/productpage) =="
+    curl -s -o /dev/null -w "  http_code=%{http_code}\n" --max-time 10 "http://${HAP}${PATH_}/productpage"
+    curl -s --max-time 10 "http://${HAP}${PATH_}/productpage" | grep -iE '<title>' | head -1
+
+
+deploy-istio:
+    juju deploy -m {{_mesh}} istio-k8s         --channel {{istio_channel}} --trust
+    juju deploy -m {{_mesh}} istio-ingress-k8s --channel {{istio_channel}} --trust
+    juju wait-for application -m {{_mesh}} istio-k8s         --query='status=="active"' --timeout=15m
+    juju wait-for application -m {{_mesh}} istio-ingress-k8s --query='status=="active"' --timeout=15m
+
+deploy-configurator:
+    juju deploy -m {{_mesh}} ingress-configurator --channel {{ic_channel}}
+
+deploy-haproxy:
+    juju deploy -m {{_proxy}} haproxy --channel {{haproxy_channel}}
+    juju wait-for application -m {{_proxy}} haproxy --query='status=="active"' --timeout=15m
+
+# --- wiring (cross-model, cross-controller) ----------------------------------
+
+relate:
+    # Offer haproxy's TCP route endpoint from the LXD controller...
+    juju offer {{lxd_ctrl}}:admin/{{proxy}}.haproxy:haproxy-route-tcp
+    # ...consume it in the k8s model and integrate with the configurator.
+    juju consume -m {{_mesh}} {{lxd_ctrl}}:admin/{{proxy}}.haproxy || true
+    juju integrate -m {{_mesh}} ingress-configurator:haproxy-route-tcp haproxy
+
+# --- configuration -----------------------------------------------------------
+# Point ingress-configurator's TCP backend at the istio-ingress LB IP (TLS off = HTTP passthrough).
+configure:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    LB=$(just _istio-lb)
+    echo "istio-ingress LB IP: ${LB}"
+    juju config -m {{_mesh}} ingress-configurator \
+        tcp-backend-addresses="${LB}" \
+        tcp-port-mapping="{{frontend_port}}:{{backend_port}}" \
+        tcp-enforce-tls=false \
+        tcp-tls-terminate=false
+    juju config -m {{_proxy}} haproxy external-hostname=haproxy.internal
+    juju wait-for application -m {{_mesh}}  ingress-configurator --query='status=="active"' --timeout=10m
+    juju wait-for application -m {{_proxy}} haproxy              --query='status=="active"' --timeout=10m
+
+# Optional: TLS passthrough (SNI-routed). haproxy does NOT terminate TLS; istio does.
+# istio-ingress gets a cert from self-signed-certificates and serves HTTPS :443 for `tls_host`.
+# haproxy inspects the TLS ClientHello SNI and forwards the encrypted stream unchanged.
+tls_host := "bookinfo.test"
+
+tls-passthrough: _tls-certs _tls-configure verify-passthrough
+
+# Deploy self-signed-certificates in both models and wire certs.
+# (SSC on the haproxy side is unused for passthrough; included to mirror the requested setup.)
+_tls-certs:
+    juju deploy -m {{_mesh}}  self-signed-certificates --channel latest/stable || true
+    juju deploy -m {{_proxy}} self-signed-certificates --channel latest/stable || true
+    juju integrate -m {{_mesh}}  self-signed-certificates:certificates istio-ingress-k8s:certificates || true
+    juju integrate -m {{_proxy}} self-signed-certificates:certificates haproxy:certificates || true
+    juju config -m {{_mesh}} istio-ingress-k8s external_hostname={{tls_host}}
+    juju wait-for application -m {{_mesh}} istio-ingress-k8s --query='status=="active"' --timeout=15m
+
+# Configure the configurator for SNI passthrough on 443 (tls terminate OFF, SNI = tls_host).
+_tls-configure:
+    juju config -m {{_mesh}} ingress-configurator \
+        tcp-port-mapping=443:443 \
+        tcp-tls-terminate=false \
+        tcp-enforce-tls=true \
+        tcp-hostname={{tls_host}}
+    juju wait-for application -m {{_mesh}} ingress-configurator --query='status=="active"' --timeout=10m
+
+# Prove passthrough: HTTPS 200 through haproxy, and the served cert is istio's (SSC-issued).
+verify-passthrough:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    HAP=$(just _haproxy-addr)
+    URL="https://{{tls_host}}/mesh-bookinfo-productpage-k8s/productpage"
+    echo "== HTTPS through haproxy (SNI={{tls_host}}) =="
+    curl -sk -o /dev/null -w "  http_code=%{http_code}\n" --max-time 12 \
+        --resolve {{tls_host}}:443:${HAP} "${URL}"
+    echo "== cert presented through haproxy (expect CN={{tls_host}}, issued by SSC = istio's cert) =="
+    echo | openssl s_client -connect ${HAP}:443 -servername {{tls_host}} 2>/dev/null \
+        | openssl x509 -noout -subject -issuer
+
+
+# --- verification ------------------------------------------------------------
+
+verify:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    LB=$(just _istio-lb)
+    HAP=$(just _haproxy-addr)
+    echo "== direct to istio-ingress (${LB}:{{backend_port}}) =="
+    curl -s -o /dev/null -w "  http_code=%{http_code}\n" --max-time 8 "http://${LB}:{{backend_port}}/"
+    echo "== through haproxy (${HAP}:{{frontend_port}}) =="
+    curl -s -i --max-time 8 "http://${HAP}:{{frontend_port}}/" | head -4
+    echo "(expect 'server: istio-envoy' -> proves the TCP path reaches istio; 404 is normal with no backend app)"
+
+status:
+    -juju status -m {{_mesh}} --relations
+    -juju status -m {{_proxy}} --relations
+
+# --- teardown ----------------------------------------------------------------
+
+clean:
+    -juju remove-offer -y {{lxd_ctrl}}:admin/{{proxy}}.haproxy --force
+    -juju destroy-model -y --no-prompt {{_mesh}}  --destroy-storage --force
+    -juju destroy-model -y --no-prompt {{_proxy}} --destroy-storage --force
+
+# --- helpers -----------------------------------------------------------------
+# istio-ingress advertises its LB IP in its workload status: "Serving at <IP>".
+_istio-lb:
+    @juju status -m {{_mesh}} --format json \
+      | jq -r '.applications."istio-ingress-k8s".units | to_entries[0].value."workload-status".message' \
+      | awk '{print $NF}'
+
+_haproxy-addr:
+    @juju status -m {{_proxy}} --format json \
+      | jq -r '.applications.haproxy.units."haproxy/0"."public-address"'


### PR DESCRIPTION
Project for exploring integrating the haproxy machine charm with the istio-ingress-k8s charm using the [ingress-configurator](https://charmhub.io/ingress-configurator) charm
