### PR TITLE
fix(envoy-ai-controller-k8s): wait for gie crds to be ready to prevent premature active

### DIFF
--- a/charms/envoy-ai-controller-k8s/src/charm.py
+++ b/charms/envoy-ai-controller-k8s/src/charm.py
@@ -543,7 +543,14 @@ class EnvoyAiControllerCharm(ops.CharmBase):
             crd = self.lightkube_client.get(
                 CustomResourceDefinition, name=INFERENCE_POOL_CRD
             )
-        except ApiError:
+        except ApiError as e:
+            if e.status.code == 404:
+                return False
+            logger.error(
+                "Unexpected API error querying InferencePool CRD (HTTP %s): %s",
+                e.status.code,
+                e.status.message,
+            )
             return False
         conditions = (crd.status.conditions if crd.status else None) or []
         return any(

--- a/charms/envoy-ai-controller-k8s/src/charm.py
+++ b/charms/envoy-ai-controller-k8s/src/charm.py
@@ -40,6 +40,7 @@ from lightkube.models.admissionregistration_v1 import (
 )
 from lightkube.models.meta_v1 import LabelSelector, ObjectMeta
 from lightkube.resources.admissionregistration_v1 import MutatingWebhookConfiguration
+from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
 from lightkube.resources.rbac_authorization_v1 import ClusterRole
 from ops.pebble import Layer
 
@@ -53,6 +54,11 @@ WEBHOOK_SCOPE = "extproc-webhook"
 
 # CRD reconcile scope -> the crds/<dir> the bundle is loaded from.
 CRD_SCOPES = {AI_CRD_SCOPE: "ai-gateway"}
+
+# The GIE InferencePool CRD the controller scans for once at startup, permanently disabling
+# its InferencePool controller if absent. Owned by the separate envoy-controller-k8s charm,
+# so this charm only gates startup on it. Mirrors upstream controller.go (inferencePoolCRD).
+INFERENCE_POOL_CRD = "inferencepools.inference.networking.k8s.io"
 
 CONTAINER = "ai-gateway"
 
@@ -329,6 +335,8 @@ class EnvoyAiControllerCharm(ops.CharmBase):
              precondition halts reconciliation; status is set via _on_collect_status.
           2. Apply CRDs — the aigateway.envoyproxy.io schemas the controller indexes
              at startup. Halts until they reach Established.
+          2b. Wait for the externally-owned GIE InferencePool CRD to be Established, so
+             the controller starts after it and registers the InferencePool watch.
           3. Push the webhook serving cert into the container.
           4. Reconcile the ExtProc MutatingWebhookConfiguration (caBundle = issuing CA),
              or tear it down when the extension-server relation is absent.
@@ -359,6 +367,14 @@ class EnvoyAiControllerCharm(ops.CharmBase):
             self._reconcile_crds()
         except _CrdsNotEstablishedError:
             logger.info("CRDs applied but not yet Established; deferring controller start")
+            return
+
+        # Step 2b: the controller scans for the externally-owned GIE InferencePool CRD once,
+        # at startup, and permanently disables its InferencePool controller if it is absent.
+        # The CRD is installed by the separate envoy-controller-k8s charm, so defer starting
+        # the controller until it is Established; a later event re-runs reconcile.
+        if not self._inference_pool_crd_established():
+            logger.info("InferencePool CRD not yet Established; deferring controller start")
             return
 
         if not self._tls_ready:
@@ -461,8 +477,16 @@ class EnvoyAiControllerCharm(ops.CharmBase):
             )
             return
         if CONTAINER not in container.get_plan().services:
-            # Reconciliation has not yet started the controller — most commonly it is
-            # still waiting for the CRDs to reach Established. Do not report Active.
+            # Reconciliation has not yet started the controller. The most actionable
+            # cause is a missing GIE InferencePool CRD (owned by envoy-controller-k8s);
+            # surface that specifically so operators know what to deploy/relate.
+            if not self._inference_pool_crd_established():
+                event.add_status(
+                    ops.WaitingStatus(
+                        "Waiting for InferencePool CRD (install envoy-controller-k8s)"
+                    )
+                )
+                return
             event.add_status(
                 ops.MaintenanceStatus("Setting up Envoy AI Gateway control plane")
             )
@@ -505,6 +529,25 @@ class EnvoyAiControllerCharm(ops.CharmBase):
         return all(
             self._crd_manager(scope).established(_load_crd_yaml(directory))
             for scope, directory in CRD_SCOPES.items()
+        )
+
+    def _inference_pool_crd_established(self) -> bool:
+        """Return True when the externally-owned GIE InferencePool CRD is Established.
+
+        The CRD is applied by the separate envoy-controller-k8s charm, so this only
+        checks presence (a missing or unqueryable CRD counts as not-Established) — the
+        controller must not start until it is served, or it permanently skips its
+        InferencePool controller.
+        """
+        try:
+            crd = self.lightkube_client.get(
+                CustomResourceDefinition, name=INFERENCE_POOL_CRD
+            )
+        except ApiError:
+            return False
+        conditions = (crd.status.conditions if crd.status else None) or []
+        return any(
+            c.type == "Established" and c.status == "True" for c in conditions
         )
 
     def _reconcile_pebble_services(self):

--- a/charms/envoy-ai-controller-k8s/tests/unit/conftest.py
+++ b/charms/envoy-ai-controller-k8s/tests/unit/conftest.py
@@ -110,6 +110,8 @@ def krm_mocks():
         EnvoyAiControllerCharm, "_crd_manager", side_effect=crd_factory
     ), patch.object(EnvoyAiControllerCharm, "_webhook_krm") as webhook, patch.object(
         EnvoyAiControllerCharm, "_crds_established", return_value=True
+    ), patch.object(
+        EnvoyAiControllerCharm, "_inference_pool_crd_established", return_value=True
     ):
         yield SimpleNamespace(
             crd=crd,

--- a/charms/envoy-ai-controller-k8s/tests/unit/test_charm.py
+++ b/charms/envoy-ai-controller-k8s/tests/unit/test_charm.py
@@ -157,6 +157,18 @@ def test_inference_pool_crd_established_false_when_absent(ctx, mock_lightkube_cl
         assert mgr.charm._inference_pool_crd_established() is False
 
 
+def test_inference_pool_crd_established_false_on_unexpected_api_error(
+    ctx, mock_lightkube_client, caplog
+):
+    # GIVEN the API server returns a non-404 error (e.g. 403 RBAC, 500 server error)
+    mock_lightkube_client.get.side_effect = _api_error(403)
+    with ctx(ctx.on.update_status(), make_state()) as mgr:
+        # THEN the method returns False (not-Established) …
+        assert mgr.charm._inference_pool_crd_established() is False
+    # … and an error is logged so operators can diagnose the real failure
+    assert any("403" in record.message for record in caplog.records)
+
+
 def test_reconcile_defers_on_api_429(ctx, krm_mocks):
     # GIVEN a freshly-Established CRD whose storage backend is still initializing —
     # the first list against a CR of that CRD returns 429 "storage is (re)initializing".

--- a/charms/envoy-ai-controller-k8s/tests/unit/test_charm.py
+++ b/charms/envoy-ai-controller-k8s/tests/unit/test_charm.py
@@ -6,6 +6,7 @@
 import base64
 import dataclasses
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import httpx
@@ -102,6 +103,58 @@ def test_maintenance_while_crds_not_established(ctx, krm_mocks):
     assert state_out.unit_status == ops.MaintenanceStatus(
         "Setting up Envoy AI Gateway control plane"
     )
+
+
+def test_defers_controller_start_until_inference_pool_crd_established(ctx, krm_mocks):
+    # GIVEN every precondition is met except the GIE InferencePool CRD, which is owned by
+    # the separate envoy-controller-k8s charm and may not exist yet on a concurrent deploy.
+    # Starting the controller now would permanently disable its InferencePool controller.
+    with patch.object(
+        EnvoyAiControllerCharm, "_inference_pool_crd_established", return_value=False
+    ):
+        # WHEN the charm reconciles
+        state_out = ctx.run(ctx.on.config_changed(), make_state())
+    # THEN the controller is not started and the unit waits with an actionable message; a
+    # later event re-runs reconcile once the CRD is served.
+    assert state_out.unit_status == ops.WaitingStatus(
+        "Waiting for InferencePool CRD (install envoy-controller-k8s)"
+    )
+    # AND the controller service was never added to the Pebble plan.
+    container = state_out.get_container("ai-gateway")
+    assert "ai-gateway" not in container.plan.services
+
+
+def test_controller_starts_once_inference_pool_crd_established(ctx, krm_mocks):
+    # GIVEN the GIE InferencePool CRD is now Established alongside every other precondition
+    with patch.object(
+        EnvoyAiControllerCharm, "_inference_pool_crd_established", return_value=True
+    ):
+        # WHEN the charm reconciles
+        state_out = ctx.run(ctx.on.config_changed(), make_state())
+    # THEN the controller service is started (so it boots with the InferencePool watch)
+    container = state_out.get_container("ai-gateway")
+    assert "ai-gateway" in container.plan.services
+
+
+def test_inference_pool_crd_established_true_when_condition_present(
+    ctx, mock_lightkube_client
+):
+    # GIVEN the GIE InferencePool CRD exists and reports Established=True
+    mock_lightkube_client.get.return_value = SimpleNamespace(
+        status=SimpleNamespace(
+            conditions=[SimpleNamespace(type="Established", status="True")]
+        )
+    )
+    with ctx(ctx.on.update_status(), make_state()) as mgr:
+        assert mgr.charm._inference_pool_crd_established() is True
+
+
+def test_inference_pool_crd_established_false_when_absent(ctx, mock_lightkube_client):
+    # GIVEN the GIE InferencePool CRD is not present yet (API server returns 404)
+    mock_lightkube_client.get.side_effect = _api_error(404)
+    with ctx(ctx.on.update_status(), make_state()) as mgr:
+        # THEN a missing CRD counts as not-Established rather than erroring
+        assert mgr.charm._inference_pool_crd_established() is False
 
 
 def test_reconcile_defers_on_api_429(ctx, krm_mocks):

--- a/charms/envoy-ai-controller-k8s/tests/unit/test_charm.py
+++ b/charms/envoy-ai-controller-k8s/tests/unit/test_charm.py
@@ -157,7 +157,7 @@ def test_inference_pool_crd_established_false_when_absent(ctx, mock_lightkube_cl
         assert mgr.charm._inference_pool_crd_established() is False
 
 
-def test_inference_pool_crd_established_false_on_unexpected_api_error(
+def test_inference_pool_crd_established_logs_and_returns_false_on_unexpected_api_error(
     ctx, mock_lightkube_client, caplog
 ):
     # GIVEN the API server returns a non-404 error (e.g. 403 RBAC, 500 server error)


### PR DESCRIPTION
Fixes #429 

The envoy ai charm was basically having a single gate check to enable gie features depending on whether or not the gie crds were installed. if the envoy-controller-k8s was late in installing the crds, then the gie features were never enabled even when the data path for those features were available. 

This fix waits for the gie crds to be installed. 

Why not move the gie crds to this charm? because the controller also has a usage path for those crds. and this is an add-on charm.

Is gie crd mandatorily necessary for this charm? If not, why are we in waiting state? No, the ai gateways core functionalilty can still work without the gie crds. but, this charm itself works only when the controller is active and the controller installs the gie crds unconditionally. Hence waiting for the gie crds which this charms needs to be featureful is a good solution