### PR TITLE
chore(istio-install-cni): bump 1.30.3 rock base to ubuntu@26.04

### DIFF
--- a/rocks/istio-install-cni-rock/1.30.3/rockcraft.yaml
+++ b/rocks/istio-install-cni-rock/1.30.3/rockcraft.yaml
@@ -5,8 +5,8 @@ name: istio-install-cni
 summary: Istio's install-cni in a rock
 description: "Installs Istio's cni plugin"
 version: "1.30.3"
-base: ubuntu@24.04
-build-base: ubuntu@24.04
+base: ubuntu@26.04
+build-base: ubuntu@26.04
 services:
   install-cni:
     command: "/usr/local/bin/install-cni"


### PR DESCRIPTION
Fixes #153

istio-pilot and istio-ztunnel's 1.30.3 rocks are already on
`ubuntu@26.04`; this brings istio-install-cni's 1.30.3 rock in line
with those two.

## Test plan
- [x] Confirmed via `diff` against the sibling istio-pilot/istio-ztunnel
      1.30.3 rockcraft.yaml files that `base`/`build-base` is the only
      field that needed to change for the 26.04 bump on this rock.
- [x] YAML parses correctly.
- [ ] Not run through `rockcraft pack` (snapd not available in my
      sandbox) — relying on this repo's `rock-pull-request.yaml` CI to
      build it.