### PR TITLE
fix: update release pipelines k8s distribution to canonical k8s

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -75,4 +75,4 @@ jobs:
       charm-path: ${{ matrix.charm-path }}
       git-tag-prefix: ${{ matrix.charm-name }}
       default-track: dev
-      provider: microk8s
+      provider: k8s


### PR DESCRIPTION
Updates the release pipeline to use ck8s. partly because envoy charms itest seems to fail on microk8s - https://github.com/canonical/service-mesh/issues/526

The direction was the the charms should primarily support canonical k8s. so updating the release ci to use canonical k8s
