### PR TITLE
chore: update charm workflows for istio 1.29 track

### DIFF
--- a/.github/workflows/charms-promote.yaml
+++ b/.github/workflows/charms-promote.yaml
@@ -11,8 +11,12 @@ on:
           - beta -> candidate
           - candidate -> stable
       charm:
-        type: string
-        description: Charm to promote (directory name under charms/)
+        type: choice
+        description: Istio charm to promote
+        options:
+          - istio-beacon-k8s
+          - istio-ingress-k8s
+          - istio-k8s
 
 jobs:
   promote:
@@ -21,4 +25,5 @@ jobs:
     with:
       promotion: ${{ github.event.inputs.promotion }}
       charm-path: charms/${{ github.event.inputs.charm }}
+      track: "1.29"
     secrets: inherit

--- a/.github/workflows/charms-release.yaml
+++ b/.github/workflows/charms-release.yaml
@@ -8,11 +8,6 @@ on:
         description: Which charm to release
         options:
           - all
-          - bookinfo-details-k8s
-          - bookinfo-productpage-k8s
-          - envoy-ai-controller-k8s
-          - envoy-controller-k8s
-          - envoy-ingress-k8s
           - istio-beacon-k8s
           - istio-ingress-k8s
           - istio-k8s
@@ -21,7 +16,9 @@ on:
       - main
       - 'track/**'
     paths:
-      - 'charms/**'
+      - 'charms/istio-beacon-k8s/**'
+      - 'charms/istio-ingress-k8s/**'
+      - 'charms/istio-k8s/**'
 
 jobs:
   set-charms:
@@ -39,11 +36,6 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         with:
           filters: |
-            bookinfo-details-k8s: charms/bookinfo-details-k8s/**
-            bookinfo-productpage-k8s: charms/bookinfo-productpage-k8s/**
-            envoy-ai-controller-k8s: charms/envoy-ai-controller-k8s/**
-            envoy-controller-k8s: charms/envoy-controller-k8s/**
-            envoy-ingress-k8s: charms/envoy-ingress-k8s/**
             istio-beacon-k8s: charms/istio-beacon-k8s/**
             istio-ingress-k8s: charms/istio-ingress-k8s/**
             istio-k8s: charms/istio-k8s/**
@@ -54,8 +46,8 @@ jobs:
             # Manual dispatch of a single charm: release only that charm.
             echo 'charms=[{"charm-path": "charms/${{ inputs.charm }}", "charm-name": "${{ inputs.charm }}"}]' >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            # Manual dispatch of 'all': release every charm.
-            echo "charms=$(ls -d1 charms/* | jq -Rsc '[split("\n")[:-1][] | {("charm-path"): ., ("charm-name"): ltrimstr("charms/")}]')" >> "$GITHUB_OUTPUT"
+            # Manual dispatch of 'all': release every Istio charm.
+            echo 'charms=[{"charm-path":"charms/istio-beacon-k8s","charm-name":"istio-beacon-k8s"},{"charm-path":"charms/istio-ingress-k8s","charm-name":"istio-ingress-k8s"},{"charm-path":"charms/istio-k8s","charm-name":"istio-k8s"}]' >> "$GITHUB_OUTPUT"
           else
             # Push: release only the charms that changed.
             echo "charms=$(echo '${{ steps.changes.outputs.changes }}' | jq -c '[.[] | {("charm-path"): ("charms/" + .), ("charm-name"): .}]')" >> "$GITHUB_OUTPUT"
@@ -78,5 +70,5 @@ jobs:
     with:
       charm-path: ${{ matrix.charm-path }}
       git-tag-prefix: ${{ matrix.charm-name }}
-      default-track: dev
+      track: "1.29"
       provider: k8s


### PR DESCRIPTION
Updates the charm release workflows so 

- releases istio charms to the 1.29 track instead of dev
- only istio charms can be released and promoted from the istio track branch 
